### PR TITLE
convenience reading, pytest, pep8, type checking, speedup, cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-sudo: required
-dist: xenial
 group: travis_latest
 
 git:
@@ -8,19 +6,22 @@ git:
   quiet: true
 
 python:
-- 3.7
+# - 3.7  # tested on AppVeyor
 - 3.6
 - 3.5
+- pypy3
 
 os:
 - linux
 
-install: pip install -e .[tests]
+install: 
+- pip install -e .[tests]
+- if [[ $TRAVIS_PYTHON_VERSION == 3.6* ]]; then pip install -e .[cov]; fi
 
 script:
 - pytest -rsv
-- flake8
-- mypy . --ignore-missing-imports
+- if [[ $TRAVIS_PYTHON_VERSION == 3.6* ]]; then flake8; fi
+- if [[ $TRAVIS_PYTHON_VERSION == 3.6* ]]; then mypy . --ignore-missing-imports; fi
 
 after_success:
 - if [[ $TRAVIS_PYTHON_VERSION == 3.6* ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ install: pip install -e .[tests]
 
 script:
 - pytest -rsv
-#- flake8
-# - mypy . --ignore-missing-imports
+- flake8
+- mypy . --ignore-missing-imports
 
 after_success:
 - if [[ $TRAVIS_PYTHON_VERSION == 3.6* ]]; then

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 [![image](https://travis-ci.com/scivision/cdflib.svg?branch=master)](https://travis-ci.com/scivision/cdflib)
 [![image](https://coveralls.io/repos/github/scivision/cdflib/badge.svg?branch=master)](https://coveralls.io/github/scivision/cdflib?branch=master)
 [![Build status](https://ci.appveyor.com/api/projects/status/kfhqkd87vifsbc9d?svg=true)](https://ci.appveyor.com/project/scivision/cdflib)
+[![PyPi version](https://img.shields.io/pypi/pyversions/cdflib.svg)](https://pypi.python.org/pypi/cdflib)
+[![PyPi formats](https://img.shields.io/pypi/format/cdflib.svg)](https://pypi.python.org/pypi/cdflib)
+[![PyPi Download stats](http://pepy.tech/badge/cdflib)](http://pepy.tech/project/cdflib)
 
 # CDFlib
 
-`cdflib` is a python module to read/write CDF (Common Data Format `.cdf`) files without needing to install the 
+`cdflib` is a python module to read/write CDF (Common Data Format `.cdf`) files without needing to install the
 [CDF NASA library](https://cdf.gsfc.nasa.gov/).
 
 Python &ge; 3.5 is required.
@@ -22,24 +25,32 @@ Future implementations, however, will unify these two classes.
 
 ## CDF Reader Class
 
-To begin accessing the data within a CDF file, first create a new CDF class. 
+To begin accessing the data within a CDF file, first create a new CDF class.
 This can be done with the following commands
 ```python
 import cdflib
 
-cdf_file = cdflib.CDF('/path/to/cdf_file.cdf')
+h = cdflib.CDF('/path/to/cdf_file.cdf')
 ```
-Then, you can call various functions on the variable. 
+Then, you can call various functions on the variable.
 For example:
 ```python
-x = cdf_file.varget("NameOfVariable", startrec = 0, endrec = 150)
+x = h.varget("varname", startrec = 0, endrec = 150)
 ```
-This command will return all data inside of the variable `Variable1`, from records 0 to 150. 
+This command will return all data inside of the variable `Variable1`, from records 0 to 150.
+
+A shortcut for reading a variable that reads all values in the variable is:
+```python
+x = h['varname']
+```
+
+At this time, a cdfread context manager isn't provided because the file read operations are atomic--the file is closed immediately after reading necessary data, and file position is preserved in the object.
+
 Below is a list of the 8 different functions you can call.
 
 ### cdf_info()
 
-Returns a dictionary that shows the basic CDF information. 
+Returns a dictionary that shows the basic CDF information.
 This information includes
 
 * `CDF` the name of the CDF
@@ -57,7 +68,7 @@ This information includes
 
 ### varinq(variable)
 
-Returns a dictionary that shows the basic variable information. 
+Returns a dictionary that shows the basic variable information.
 This information includes
 * `Variable` the name of the variable
 * `Num` the variable number
@@ -93,8 +104,8 @@ dictionary is returned with the following defined keys
 
 ### varattsget(variable = None, expand = False)
 
-Gets all variable attributes. 
-Unlike attget, which returns a single attribute entry value, this function returns all of the variable attribute entries, in a `dict()`. 
+Gets all variable attributes.
+Unlike attget, which returns a single attribute entry value, this function returns all of the variable attribute entries, in a `dict()`.
 If there is no entry found, `None` is returned. If
 no variable name is provided, a list of variables are printed. If expand
 is entered with non-False, then each entry's data type is also returned
@@ -142,14 +153,14 @@ possible minimum or maximum value for the specific epoch data type is
 assumed. If either the start or end record is not specified, the range
 starts at 0 or/and ends at the last of the written data.
 
-The start (and end) time should be presented in a list as: 
-* [year month day hour minute second millisec] for CDF_EPOCH 
+The start (and end) time should be presented in a list as:
+* [year month day hour minute second millisec] for CDF_EPOCH
 * [year month day hour minute second millisec microsec nanosec picosec] for CDF_EPOCH16
-* [year month day hour minute second millisec microsec nanosec] for CDF_TIME_TT2000 
+* [year month day hour minute second millisec microsec nanosec] for CDF_TIME_TT2000
 
 If not enough time components are presented, only the last item can have the floating portion for the sub-time components.
 
-Note: CDF's CDF_EPOCH16 data type uses 2 8-byte doubles for each data value. 
+Note: CDF's CDF_EPOCH16 data type uses 2 8-byte doubles for each data value.
 In Python, each value is presented as a complex or
 numpy.complex128.
 
@@ -158,8 +169,8 @@ numpy.complex128.
 ```python
 epochrange( epoch, [starttime=None, endtime=None])
 ```
-Get epoch range. 
-Returns `list()` of the record numbers, representing the corresponding starting and ending records within the time range from the epoch data. 
+Get epoch range.
+Returns `list()` of the record numbers, representing the corresponding starting and ending records within the time range from the epoch data.
 `None` is returned if there is no data either written or found in the time range.
 
 ### getVersion ()
@@ -167,9 +178,9 @@ Returns `list()` of the record numbers, representing the corresponding starting 
 Shows the code version.
 
 ```python
-import cdflib 
+import cdflib
 
-swea_cdf_file = cdflib.CDF('/path/to/swea_file.cdf') swea_cdf_file.cdf_info() 
+swea_cdf_file = cdflib.CDF('/path/to/swea_file.cdf') swea_cdf_file.cdf_info()
 
 x = swea_cdf_file.varget('NameOfVariable') swea_cdf_file.close()
 ```
@@ -179,7 +190,7 @@ x = swea_cdf_file.varget('NameOfVariable') swea_cdf_file.close()
 ### CDF (path, cdf_spec=None, delete=False)
 
 Creates an empty CDF file. path is the path name of the CDF (with or
-without .cdf extension). 
+without .cdf extension).
 `cdf_spec` is the optional specification of the
 CDF file, in the form of a dictionary. The dictionary can have the
 following values:
@@ -235,23 +246,23 @@ Writes a variable's attributes, provided the variable already exists.
 its entry value pair(s). The entry value is also a dictionary of
 variable id and value pair(s). Variable id can be the variable name or
 its id number in the file. Use write_var function if the variable does
-not exist. 
+not exist.
 For example:
 ```python
-variableAttrs={} 
+variableAttrs={}
 entries_1={}
 
 entries_1['var_name_1'] = 'abcd'
-entries_1['var_name_2'] = [12, 'cdf_int4'] 
+entries_1['var_name_2'] = [12, 'cdf_int4']
 ....
-variableAttrs['attr_name_1'] = entries_1 
+variableAttrs['attr_name_1'] = entries_1
 
 entries_2={}
-entries_2['var_name_1'] = 'xyz' 
-entries_2['var_name_2'] = [[12, 34], 'cdf_int4'] 
+entries_2['var_name_1'] = 'xyz'
+entries_2['var_name_2'] = [[12, 34], 'cdf_int4']
 ....
-variableAttrs['attr_name_2']=entries_2 
-.... 
+variableAttrs['attr_name_2']=entries_2
+....
 f.write_variableattrs(variableAttrs)
 ```
 
@@ -283,13 +294,13 @@ Optional keys:
 * `Compress` Set the gzip compression level (0 to 9), 0 for no compression. The default is to compress with level 6 (done only if the compressed data is less than the uncompressed data).
 * `Block_Factor` The blocking factor, the number of records in a chunk when the variable is compressed.
 * `Pad` The padded value (in bytes, numpy.ndarray or string)
-      
+
 **var_attrs** is a dictionary, with {attribute:value} pairs. The
 attribute is the name of a variable attribute. The value can have its
 data type specified for the numeric data. If not, based on Python's
 type, a corresponding CDF type is assumed: CDF_INT4 for int,
 CDF_DOUBLE for float, CDF_EPOCH16 for complex and and CDF_INT8 for
-long. For example: 
+long. For example:
 ```python
 var_attrs= { 'attr1': 'value1', 'attr2': 12.45, 'attr3': [3,4,5], .....} -or- var_attrs= { 'attr1': 'value1', 'attr2': [12.45, 'CDF_DOUBLE'], 'attr3': [[3,4,5], 'CDF_INT4'], ..... }
 ```
@@ -306,7 +317,7 @@ number of records as the first element) or have data from both physical
 records and virtual records (which with filled data). The var_data has
 the form:
 ```python
-[[[rec]()#1,rec_#2,rec_#3,...], [[data]()#1,data_#2,data_#3,...]] 
+[[[rec]()#1,rec_#2,rec_#3,...], [[data]()#1,data_#2,data_#3,...]]
 ```
 See the sample for its setup.
 
@@ -316,7 +327,7 @@ Shows the code version and modified date.
 
 Note: The attribute entry value for the CDF epoch data type, CDF_EPOCH,
 CDF_EPOCH16 or CDF_TIME_TT2000, can be presented in either a numeric
-form, or an encoded string form. 
+form, or an encoded string form.
 For numeric, the CDF_EPOCH data is 8-byte float, CDF_EPOCH16 16-byte complex and CDF_TIME_TT2000 8-byte
 long. The default encoded string for the epoch `data should have this
 form:
@@ -330,8 +341,8 @@ where mon is a 3-character month.
 Sample use -
 
 Use a master CDF file as the template for creating a CDF. Both global
-and variable meta-data comes from the master CDF. 
-Each variable's specification also is copied from the master CDF. 
+and variable meta-data comes from the master CDF.
+Each variable's specification also is copied from the master CDF.
 Just fill the variable data to write a new CDF file:
 
 ```python
@@ -347,7 +358,7 @@ cdf_file=cdfwrite.CDF('/path/to/swea_file.cdf',cdf_spec=info,delete=True)
 if (cdf_file.file == None):
     cdf_master.close()
     raise OSError('Problem writing file.... Stop')
-    
+
 # Get the global attributes
 globalaAttrs=cdf_master.globalattsget(expand=True)
 # Write the global attributes
@@ -379,7 +390,7 @@ for x in range (0, len(zvars)):
         # 3 physical records at [0,5,10]:
         # vardata = [[  5.55000000e+01, -1.00000002e+30,  6.65999985e+01],
         #            [  6.66659973e+02,  7.77770020e+02,  8.88880005e+02],
-        #            [  2.00500000e+02,  2.10600006e+02,  2.20699997e+02]] 
+        #            [  2.00500000e+02,  2.10600006e+02,  2.20699997e+02]]
         # Or, with virtual record data embedded in the data:
         # vardata = [[  5.55000000e+01, -1.00000002e+30,  6.65999985e+01],
         #            [ -1.00000002e+30, -1.00000002e+30, -1.00000002e+30],
@@ -468,7 +479,7 @@ Encodes the epoch(s) into UTC string(s).
 
 ### unixtime (epochs, to_np=False)
 
-Encodes the epoch(s) into seconds after 1970-01-01. 
+Encodes the epoch(s) into seconds after 1970-01-01.
 Precision is only kept to the nearest microsecond.
 
 If `to_np=True`, then the values will be returned in a numpy array.
@@ -491,7 +502,7 @@ For CDF_EPOCH: For computing into CDF_EPOCH value, each date/time elements shoul
 have exactly seven (7) components, as year, month, day, hour,
 minute, second and millisecond, in a list. For example:
 ```python
-[[2017,1,1,1,1,1,111],[2017,2,2,2,2,2,222]] 
+[[2017,1,1,1,1,1,111],[2017,2,2,2,2,2,222]]
 ```
 Or, call function
 compute_epoch directly, instead, with at least three (3) first (up

--- a/cdflib/__init__.py
+++ b/cdflib/__init__.py
@@ -1,15 +1,17 @@
-import os
+from pathlib import Path
 from . import cdfread
 from . import cdfwrite
-from .epochs import CDFepoch as cdfepoch
+from .epochs import CDFepoch as cdfepoch  # noqa: F401
 
 # This function determines if we are reading or writing a file
 
 
-def CDF(path, cdf_spec=None, delete=False, validate=None):
-    if (os.path.exists(path)):
+def CDF(path, cdf_spec=None, delete: bool=False, validate=None):
+    path = Path(path).expanduser()
+
+    if path.is_file():
         if delete:
-            os.remove(path)
+            path.unlink()
             return
         else:
             return cdfread.CDF(path, validate=validate)

--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -101,7 +101,7 @@ class CDF(object):
             raise OSError('This package does not support multi-format CDF')
 
         if cdr_info['encoding'] in (3, 14, 15):
-            raise OSError('This package does not support CDFs with this ' + CDF._encoding_token(cdr_info['encoding'])+' encoding')
+            raise OSError('This package does not support CDFs with this ' + _encoding_token(cdr_info['encoding'])+' encoding')
 
         # SET GLOBAL VARIABLES
         self._post25 = cdr_info['post25']
@@ -828,7 +828,7 @@ class CDF(object):
                 adr_info = self._read_adr(position)
             else:
                 adr_info = self._read_adr2(position)
-            attr[adr_info['name']] = CDF._scope_token(int(adr_info['scope']))
+            attr[adr_info['name']] = _scope_token(int(adr_info['scope']))
             attrs.append(attr)
             position = adr_info['next_adr_location']
         return attrs

--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -47,6 +47,7 @@ import struct
 import gzip
 import hashlib
 import cdflib.epochs as epoch
+from typing import Tuple, Dict, Any, Union, Sequence
 
 
 class CDF(object):
@@ -65,7 +66,7 @@ class CDF(object):
 
         self.file = path
 
-        with self.file.open('rb')  as f:
+        with self.file.open('rb') as f:
             magic_number = f.read(4).hex()
             compressed_bool = f.read(4).hex()
 
@@ -81,7 +82,7 @@ class CDF(object):
             new_path = self._uncompress_file(path)
             if new_path is None:
                 raise OSError("Decompression was unsuccessful.  Only GZIP compression is currently supported.")
-                
+
             self.compressed_file = self.file
             self.file = new_path
 
@@ -106,7 +107,7 @@ class CDF(object):
         self._post25 = cdr_info['post25']
         self._version = cdr_info['version']
         self._encoding = cdr_info['encoding']
-        self._majority = CDF._major_token(cdr_info['majority'])
+        self._majority = _major_token(cdr_info['majority'])
         self._copyright = cdr_info['copyright']
         self._md5 = cdr_info['md5']
         self._first_zvariable = gdr_info['first_zvariable']
@@ -125,6 +126,8 @@ class CDF(object):
         if self.compressed_file is not None:
             self.compressed_file = None
 
+    def __getitem__(self, variable: str) -> np.ndarray:
+        return self.varget(variable)
 
     def cdf_info(self):
         """
@@ -175,7 +178,7 @@ class CDF(object):
             mycdf_info['LeapSecondUpdated'] = self._leap_second_updated
         return mycdf_info
 
-    def varinq(self, variable):
+    def varinq(self, variable) -> Dict[str, Any]:
         """
         Returns a dictionary that shows the basic variable information.
 
@@ -211,31 +214,34 @@ class CDF(object):
                 +-----------------+--------------------------------------------------------------------------------+
         """
         vdr_info = self.varget(variable=variable, inq=True)
-        if vdr_info == None:
+        if vdr_info is None:
             raise KeyError("Variable {} not found.".format(variable))
 
         var = {}
         var['Variable'] = vdr_info['name']
         var['Num'] = vdr_info['variable_number']
-        var['Var_Type'] = CDF._variable_token(vdr_info['section_type'])
+        var['Var_Type'] = _variable_token(vdr_info['section_type'])
         var['Data_Type'] = vdr_info['data_type']
-        var['Data_Type_Description'] = CDF._datatype_token(vdr_info['data_type'])
+        var['Data_Type_Description'] = _datatype_token(vdr_info['data_type'])
         var['Num_Elements'] = vdr_info['num_elements']
         var['Num_Dims'] = vdr_info['num_dims']
         var['Dim_Sizes'] = vdr_info['dim_sizes']
-        var['Sparse'] = CDF._sparse_token(vdr_info['sparse'])
+        var['Sparse'] = _sparse_token(vdr_info['sparse'])
         var['Last_Rec'] = vdr_info['max_records']
         var['Rec_Vary'] = vdr_info['record_vary']
         var['Dim_Vary'] = vdr_info['dim_vary']
-        if ('pad' in vdr_info):
+
+        if 'pad' in vdr_info:
             var['Pad'] = vdr_info['pad']
+
         var['Compress'] = vdr_info['compression_level']
-        if ('blocking_factor' in vdr_info):
+
+        if 'blocking_factor' in vdr_info:
             var['Block_Factor'] = vdr_info['blocking_factor']
 
         return var
 
-    def attinq(self, attribute=None):
+    def attinq(self, attribute: Union[str, int]=None):
         """
         Returns a python dictionary of attribute information.
 
@@ -243,7 +249,7 @@ class CDF(object):
         """
         position = self._first_adr
         if isinstance(attribute, str):
-            for _ in range(0, self._num_att):
+            for _ in range(self._num_att):
                 if (self.cdfversion == 3):
                     name, next_adr = self._read_adr_fast(position)
                 else:
@@ -259,7 +265,7 @@ class CDF(object):
         elif isinstance(attribute, int):
             if (attribute < 0 or attribute > self._num_zvariable):
                 raise KeyError('No attribute {}'.format(attribute))
-            for _ in range(0, attribute):
+            for _ in range(attribute):
                 if (self.cdfversion == 3):
                     name, next_adr = self._read_adr_fast(position)
                 else:
@@ -275,7 +281,7 @@ class CDF(object):
 
             attrs = self._get_attnames()
             print(attrs)
-            for x in range(0, self._num_att):
+            for x in range(self._num_att):
                 name = list(attrs[x].keys())[0]
                 print('NAME: ' + name + ', NUMBER: ' + str(x) + ', SCOPE: ' + attrs[x][name])
             return attrs
@@ -303,7 +309,7 @@ class CDF(object):
         # Get Correct ADR
         adr_info = None
         if isinstance(attribute, str):
-            for _ in range(0, self._num_att):
+            for _ in range(self._num_att):
                 if (self.cdfversion == 3):
                     name, next_adr = self._read_adr_fast(position)
                 else:
@@ -316,8 +322,7 @@ class CDF(object):
                     break
                 else:
                     position = next_adr
-
-            if adr_info == None:
+            if adr_info is None:
                 raise KeyError('No attribute {}'.format(attribute))
 
         elif isinstance(attribute, int):
@@ -326,7 +331,7 @@ class CDF(object):
             if not isinstance(entry, int):
                 raise TypeError('{} has to be a number.'.format(entry))
 
-            for _ in range(0, attribute):
+            for _ in range(attribute):
                 if (self.cdfversion == 3):
                     name, next_adr = self._read_adr_fast(position)
                 else:
@@ -339,7 +344,7 @@ class CDF(object):
         else:
             print('Please set attribute keyword equal to the name or ',
                   'number of an attribute')
-            for x in range(0, self._num_att):
+            for x in range(self._num_att):
                 if (self.cdfversion == 3):
                     name, next_adr = self._read_adr_fast(position)
                 else:
@@ -351,8 +356,8 @@ class CDF(object):
         # Find the correct entry from the "entry" variable
         if adr_info['scope'] == 1:
             if not isinstance(entry, int):
-                print('Global entry should be an integer')
-                return
+                raise TypeError('Global entry should be an integer')
+
             num_entry_string = 'num_gr_entry'
             first_entry_string = 'first_gr_entry'
             max_entry_string = 'max_gr_entry'
@@ -363,12 +368,12 @@ class CDF(object):
             if isinstance(entry, str):
                 # a zVariable?
                 positionx = self._first_zvariable
-                for x in range(0, self._num_zvariable):
+                for x in range(self._num_zvariable):
                     if (self.cdfversion == 3):
                         name, vdr_next = self._read_vdr_fast(positionx)
                     else:
                         name, vdr_next = self._read_vdr_fast2(positionx)
-                    if (name.strip().lower() == entry.strip().lower()):
+                    if name.strip().lower() == entry.strip().lower():
                         var_num = x
                         zvar = True
                         break
@@ -376,7 +381,7 @@ class CDF(object):
                 if var_num == -1:
                     # a rVariable?
                     positionx = self._first_rvariable
-                    for x in range(0, self._num_rvariable):
+                    for x in range(self._num_rvariable):
                         if (self.cdfversion == 3):
                             name, vdr_next = self._read_vdr_fast(positionx)
                         else:
@@ -386,13 +391,13 @@ class CDF(object):
                             break
                         positionx = vdr_next
                 if var_num == -1:
-                    print('No variable by this name:', entry)
-                    return
+                    raise KeyError('No variable {}'.format(entry))
+
                 entry_num = var_num
             else:
-                if (self._num_zvariable > 0 and self._num_rvariable > 0):
-                    print('This CDF has both r and z variables. Use variable name')
-                    return
+                if self._num_zvariable > 0 and self._num_rvariable > 0:
+                    raise ValueError('This CDF has both r and z variables. Use variable name')
+
                 if self._num_zvariable > 0:
                     zvar = True
                 entry_num = entry
@@ -405,8 +410,8 @@ class CDF(object):
                 first_entry_string = 'first_gr_entry'
                 max_entry_string = 'max_gr_entry'
         if entry_num > adr_info[max_entry_string]:
-            print('The entry does not exist')
-            return
+            raise LookupError('The entry does not exist')
+
         return self._get_attdata(adr_info, entry_num, adr_info[num_entry_string],
                                  adr_info[first_entry_string], to_np=to_np)
 
@@ -464,16 +469,11 @@ class CDF(object):
         Note: CDF's CDF_EPOCH16 data type uses 2 8-byte doubles for each data value.
         In Python, each value is presented as a complex or numpy.complex128.
         """
-        if (isinstance(variable, int) and self._num_zvariable > 0 and
-                self._num_rvariable > 0):
-            print('This CDF has both r and z variables. Use variable name')
-            return
+        if (isinstance(variable, int) and self._num_zvariable > 0 and self._num_rvariable > 0):
+            raise NameError('This CDF has both r and z variables. Use variable name')
 
-
-        if ((starttime is not None or endtime is not None) and
-                (startrec != 0 or endrec is not None)):
-            print('Can\'t specify both time and record range')
-            return
+        if (starttime is not None or endtime is not None) and (startrec != 0 or endrec is not None):
+            raise IndexError('Cannot specify both time and record range')
 
         if isinstance(variable, str):
             # Check z variables for the name, then r variables
@@ -481,7 +481,7 @@ class CDF(object):
             num_variables = self._num_zvariable
             vdr_info = None
             for zVar in [1, 0]:
-                for _ in range(0, num_variables):
+                for _ in range(num_variables):
                     if (self.cdfversion == 3):
                         name, vdr_next = self._read_vdr_fast(position)
                     else:
@@ -496,8 +496,8 @@ class CDF(object):
                 position = self._first_rvariable
                 num_variables = self._num_rvariable
             if vdr_info is None:
-                print("Variable name not found.")
-                return
+                raise KeyError("Variable name not found.")
+
         elif isinstance(variable, int):
             if self._num_zvariable > 0:
                 position = self._first_zvariable
@@ -508,9 +508,9 @@ class CDF(object):
                 num_variable = self._num_rvariable
                 # zVar = False
             if (variable < 0 or variable >= num_variable):
-                print('No variable by this number:', variable)
-                return
-            for _ in range(0, variable):
+                raise KeyError('No variable by number: {}'.format(variable))
+
+            for _ in range(variable):
                 if (self.cdfversion == 3):
                     name, next_vdr = self._read_vdr_fast(position)
                 else:
@@ -536,7 +536,7 @@ class CDF(object):
             return vdr_info
         else:
             if (vdr_info['max_records'] < 0):
-                    #print('No data is written for this variable')
+                    # print('No data is written for this variable')
                 return None
             return self._read_vardata(vdr_info, epoch=epoch, starttime=starttime, endtime=endtime,
                                       startrec=startrec, endrec=endrec, record_range_only=record_range_only,
@@ -551,8 +551,7 @@ class CDF(object):
         range from the epoch data. A None is returned if there is no
         data either written or found in the time range.
         """
-        return self.varget(variable=epoch, starttime=starttime,
-                           endtime=endtime, record_range_only=True)
+        return self.varget(variable=epoch, starttime=starttime, endtime=endtime, record_range_only=True)
 
     def globalattsget(self, expand=False, to_np=True):
         """
@@ -568,7 +567,7 @@ class CDF(object):
         """
         byte_loc = self._first_adr
         return_dict = {}
-        for _ in range(0, self._num_att):
+        for _ in range(self._num_att):
             if (self.cdfversion == 3):
                 adr_info = self._read_adr(byte_loc)
             else:
@@ -577,26 +576,26 @@ class CDF(object):
                 byte_loc = adr_info['next_adr_location']
                 continue
             if (adr_info['num_gr_entry'] == 0):
-                if (expand is not False):
+                if expand:
                     return_dict[adr_info['name']] = None
                 byte_loc = adr_info['next_adr_location']
                 continue
-            if (expand is False):
+            if not expand:
                 entries = []
             else:
                 entries = {}
             aedr_byte_loc = adr_info['first_gr_entry']
-            for _ in range(0, adr_info['num_gr_entry']):
+            for _ in range(adr_info['num_gr_entry']):
                 if (self.cdfversion == 3):
                     aedr_info = self._read_aedr(aedr_byte_loc, to_np=to_np)
                 else:
                     aedr_info = self._read_aedr2(aedr_byte_loc, to_np=to_np)
                 entryData = aedr_info['entry']
-                if (expand is False):
+                if not expand:
                     entries.append(entryData)
                 else:
                     entryWithType = []
-                    if (isinstance(entryData, str)):
+                    if isinstance(entryData, str):
                         entryWithType.append(entryData)
                     else:
                         dataType = aedr_info['data_type']
@@ -618,12 +617,12 @@ class CDF(object):
                                                                                iso_8601=False))
                                 else:
                                     entryWithType.append(epoch.CDFepoch.encode(entryData.tolist()))
-                    entryWithType.append(CDF._datatype_token(aedr_info['data_type']))
+                    entryWithType.append(_datatype_token(aedr_info['data_type']))
                     entries[aedr_info['entry_num']] = entryWithType
                 aedr_byte_loc = aedr_info['next_aedr']
 
             if (len(entries) != 0):
-                if (expand is False):
+                if not expand:
                     if (len(entries) == 1):
                         return_dict[adr_info['name']] = entries[0]
                     else:
@@ -648,14 +647,14 @@ class CDF(object):
         For attributes without any entries, they will also return with
         None value.
         """
-        if (isinstance(variable, int) and self._num_zvariable > 0 and self._num_rvariable > 0):
-            print('This CDF has both r and z variables. Use variable name')
-            return None
+        if isinstance(variable, int) and self._num_zvariable > 0 and self._num_rvariable > 0:
+            raise ValueError('This CDF has both r and z variables. Use variable name')
+
         if isinstance(variable, str):
             position = self._first_zvariable
             num_variables = self._num_zvariable
             for zVar in [1, 0]:
-                for _ in range(0, num_variables):
+                for _ in range(num_variables):
                     if (self.cdfversion == 3):
                         name, vdr_next = self._read_vdr_fast(position)
                     else:
@@ -669,8 +668,8 @@ class CDF(object):
                     position = vdr_next
                 position = self._first_rvariable
                 num_variables = self._num_rvariable
-            print('No variable by this name:', variable)
-            return None
+            raise LookupError('No variable {}'.format(variable))
+
         elif isinstance(variable, int):
             if self._num_zvariable > 0:
                 num_variable = self._num_zvariable
@@ -702,7 +701,7 @@ class CDF(object):
         '''
 
         with self.file.open('rb') as f:
-            if (self.cdfversion == 3):
+            if self.cdfversion == 3:
                 data_start, data_size, cType, _ = self._read_ccr(8)
             else:
                 data_start, data_size, cType, _ = self._read_ccr2(8)
@@ -720,20 +719,20 @@ class CDF(object):
 
         return newpath
 
-    def _read_ccr(self, byte_loc):
+    def _read_ccr(self, byte_loc: int):
         with self.file.open('rb') as f:
             f.seek(byte_loc, 0)
             block_size = int.from_bytes(f.read(8), 'big')
             f.seek(byte_loc+12)
             cproffset = int.from_bytes(f.read(8), 'big')
-            
+
         data_start = byte_loc + 32
         data_size = block_size - 32
         cType, cParams = self._read_cpr(cproffset)
 
         return data_start, data_size, cType, cParams
 
-    def _read_ccr2(self, byte_loc):
+    def _read_ccr2(self, byte_loc: int):
         with self.file.open('rb') as f:
             f.seek(byte_loc, 0)
             block_size = int.from_bytes(f.read(4), 'big')
@@ -746,7 +745,7 @@ class CDF(object):
 
         return data_start, data_size, cType, cParams
 
-    def _read_cpr(self, byte_loc):
+    def _read_cpr(self, byte_loc: int):
         with self.file.open('rb') as f:
             f.seek(byte_loc, 0)
             block_size = int.from_bytes(f.read(8), 'big')
@@ -757,13 +756,13 @@ class CDF(object):
 
         return cType, cParams
 
-    def _read_cpr2(self, byte_loc):
+    def _read_cpr2(self, byte_loc: int):
 
         with self.file.open('rb') as f:
             f.seek(byte_loc, 0)
             block_size = int.from_bytes(f.read(4), 'big')
             cpr = f.read(block_size-4)
-            
+
         cType = int.from_bytes(cpr[4:8], 'big')
         cParams = int.from_bytes(cpr[16:20], 'big')
 
@@ -795,71 +794,13 @@ class CDF(object):
 
         return md5.hexdigest() == existing_md5
 
-    def _encoding_token(encoding):   # @NoSelf
-        encodings = {1: 'NETWORK',
-                     2: 'SUN',
-                     3: 'VAX',
-                     4: 'DECSTATION',
-                     5: 'SGi',
-                     6: 'IBMPC',
-                     7: 'IBMRS',
-                     9: 'PPC',
-                     11: 'HP',
-                     12: 'NeXT',
-                     13: 'ALPHAOSF1',
-                     14: 'ALPHAVMSd',
-                     15: 'ALPHAVMSg',
-                     16: 'ALPHAVMSi'}
-        return encodings[encoding]
-
-    def _major_token(major):   # @NoSelf
-        majors = {1: 'Row_major',
-                  2: 'Column_major'}
-        return majors[major]
-
-    def _scope_token(scope):   # @NoSelf
-        scopes = {1: 'Global',
-                  2: 'Variable'}
-        return scopes[scope]
-
-    def _variable_token(variable):   # @NoSelf
-        variables = {3: 'rVariable',
-                     8: 'zVariable'}
-        return variables[variable]
-
-    def _datatype_token(datatype):   # @NoSelf
-        datatypes = {1: 'CDF_INT1',
-                     2: 'CDF_INT2',
-                     4: 'CDF_INT4',
-                     8: 'CDF_INT8',
-                     11: 'CDF_UINT1',
-                     12: 'CDF_UINT2',
-                     14: 'CDF_UINT4',
-                     21: 'CDF_REAL4',
-                     22: 'CDF_REAL8',
-                     31: 'CDF_EPOCH',
-                     32: 'CDF_EPOCH16',
-                     33: 'CDF_TIME_TT2000',
-                     41: 'CDF_BYTE',
-                     44: 'CDF_FLOAT',
-                     45: 'CDF_DOUBLE',
-                     51: 'CDF_CHAR',
-                     52: 'CDF_UCHAR'}
-        return datatypes[datatype]
-
-    def _sparse_token(sparse):   # @NoSelf
-        sparses = {0: 'No_sparse',
-                   1: 'Pad_sparse',
-                   2: 'Prev_sparse'}
-        return sparses[sparse]
-
     def _get_varnames(self):
         zvars = []
         rvars = []
         if self._num_zvariable > 0:
             position = self._first_zvariable
             num_variable = self._num_zvariable
-            for _ in range(0, num_variable):
+            for _ in range(num_variable):
                 if (self.cdfversion == 3):
                     name, next_vdr = self._read_vdr_fast(position)
                 else:
@@ -869,7 +810,7 @@ class CDF(object):
         if self._num_rvariable > 0:
             position = self._first_rvariable
             num_variable = self._num_rvariable
-            for _ in range(0, num_variable):
+            for _ in range(num_variable):
                 if (self.cdfversion == 3):
                     name, next_vdr = self._read_vdr_fast(position)
                 else:
@@ -881,7 +822,7 @@ class CDF(object):
     def _get_attnames(self):
         attrs = []
         position = self._first_adr
-        for _ in range(0, self._num_att):
+        for _ in range(self._num_att):
             attr = {}
             if (self.cdfversion == 3):
                 adr_info = self._read_adr(position)
@@ -892,8 +833,7 @@ class CDF(object):
             position = adr_info['next_adr_location']
         return attrs
 
-
-    def _read_cdr(self, byte_loc: int):
+    def _read_cdr(self, byte_loc: int) -> Tuple[Dict[str, Any], int]:
         with self.file.open('rb') as f:
             f.seek(byte_loc, 0)
             block_size = int.from_bytes(f.read(8), 'big')
@@ -910,7 +850,8 @@ class CDF(object):
 
         # FLAG
         #
-        # 0 The majority of variable values within a variable record. Variable records are described in Chapter 4. Set indicates row-majority. Clear indicates column-majority.
+        # 0 The majority of variable values within a variable record. Variable records are described in Chapter 4.
+        #    Set indicates row-majority. Clear indicates column-majority.
         # 1 The file format of the CDF. Set indicates single-file. Clear indicates multi-file.
         # 2 The checksum of the CDF. Set indicates a checksum method is used.
         # 3 The MD5 checksum method indicator. Set indicates MD5 method is used for the checksum. Bit 2 must be set.
@@ -918,8 +859,8 @@ class CDF(object):
 
         flag = int.from_bytes(cdr[24:28], 'big')
         flag_bits = '{0:032b}'.format(flag)
-        row_majority = (flag_bits[31] == '1')
-        single_format = (flag_bits[30] == '1')
+        row_majority = flag_bits[31] == '1'
+        single_format = flag_bits[30] == '1'
         md5 = (flag_bits[29] == '1' and flag_bits[28] == '1')
         increment = int.from_bytes(cdr[36:40], 'big')
         cdfcopyright = cdr[48:].decode('utf-8')
@@ -928,19 +869,15 @@ class CDF(object):
         cdr_info = {}
         cdr_info['encoding'] = encoding
         cdr_info['copyright'] = cdfcopyright
-        cdr_info['version'] = str(version) + '.' + str(release) + '.' +  \
-            str(increment)
-        if row_majority:
-            cdr_info['majority'] = 1
-        else:
-            cdr_info['majority'] = 2
+        cdr_info['version'] = '{}.{}.{}'.format(version, release, increment)  # type: ignore
+        cdr_info['majority'] = 1 if row_majority else 2
         cdr_info['format'] = single_format
         cdr_info['md5'] = md5
         cdr_info['post25'] = True
 
         return cdr_info, foffs
 
-    def _read_cdr2(self, byte_loc):
+    def _read_cdr2(self, byte_loc: int):
         with self.file.open('rb') as f:
             f.seek(byte_loc, 0)
             block_size = int.from_bytes(f.read(4), 'big')
@@ -963,22 +900,15 @@ class CDF(object):
         cdr_info = {}
         cdr_info['encoding'] = encoding
         cdr_info['copyright'] = cdfcopyright
-        cdr_info['version'] = str(version) + '.' + str(release) + '.' + \
-            str(increment)
-        if row_majority:
-            cdr_info['majority'] = 1
-        else:
-            cdr_info['majority'] = 2
+        cdr_info['version'] = '{}.{}.{}'.format(version, release, increment)  # type: ignore
+        cdr_info['majority'] = 1 if row_majority else 2
         cdr_info['format'] = single_format
         cdr_info['md5'] = md5
-        if (version == 2 and release >= 5):
-            cdr_info['post25'] = True
-        else:
-            cdr_info['post25'] = False
+        cdr_info['post25'] = version == 2 and release >= 5
 
         return cdr_info, foffs
 
-    def _read_gdr(self, byte_loc):
+    def _read_gdr(self, byte_loc: int) -> Dict[str, Any]:
         with self.file.open('rb') as f:
             f.seek(byte_loc, 0)
             block_size = int.from_bytes(f.read(8), 'big')  # Block Size
@@ -997,7 +927,7 @@ class CDF(object):
         # A bunch of 4 byte integers in a row.  Length is (size of GDR) - 84
         # In this case. there is nothing
         rdim_sizes = []
-        for x in range(0, num_rdim):
+        for x in range(num_rdim):
             ioff = 76 + x * 4
             rdim_sizes.append(int.from_bytes(gdr[ioff:ioff+4], 'big',
                                              signed=True))
@@ -1010,13 +940,13 @@ class CDF(object):
         gdr_info['num_rvariables'] = num_rvariable
         gdr_info['num_attributes'] = num_att
         gdr_info['rvariables_num_dims'] = num_rdim
-        gdr_info['rvariables_dim_sizes'] = rdim_sizes
+        gdr_info['rvariables_dim_sizes'] = rdim_sizes  # type: ignore
         gdr_info['eof'] = eof
         gdr_info['leapsecond_updated'] = leapSecondlastUpdated
 
         return gdr_info
 
-    def _read_gdr2(self, byte_loc):
+    def _read_gdr2(self, byte_loc: int) -> Dict[str, Any]:
         with self.file.open('rb') as f:
             f.seek(byte_loc, 0)
             block_size = int.from_bytes(f.read(4), 'big')  # Block Size
@@ -1031,7 +961,7 @@ class CDF(object):
         num_rdim = int.from_bytes(gdr[32:36], 'big', signed=True)
         num_zvariable = int.from_bytes(gdr[36:40], 'big', signed=True)
         rdim_sizes = []
-        for x in range(0, num_rdim):
+        for x in range(num_rdim):
             ioff = 56 + x * 4
             rdim_sizes.append(int.from_bytes(gdr[ioff:ioff+4], 'big',
                                              signed=True))
@@ -1044,15 +974,17 @@ class CDF(object):
         gdr_info['num_rvariables'] = num_rvariable
         gdr_info['num_attributes'] = num_att
         gdr_info['rvariables_num_dims'] = num_rdim
-        gdr_info['rvariables_dim_sizes'] = rdim_sizes
+        gdr_info['rvariables_dim_sizes'] = rdim_sizes  # type: ignore
         gdr_info['eof'] = eof
 
         return gdr_info
 
-    def _read_varatts(self, var_num, zVar, expand, to_np=True):
+    def _read_varatts(self, var_num, zVar, expand, to_np: bool=True) -> dict:
         byte_loc = self._first_adr
         return_dict = {}
-        for z in range(0, self._num_att):
+        CDFepoch = epoch.CDFepoch()
+
+        for z in range(self._num_att):
             if (self.cdfversion == 3):
                 adr_info = self._read_adr(byte_loc)
             else:
@@ -1067,7 +999,7 @@ class CDF(object):
                 byte_loc = adr_info['first_gr_entry']
                 num_entry = adr_info['num_gr_entry']
             found = 0
-            for _ in range(0, num_entry):
+            for _ in range(num_entry):
                 if (self.cdfversion == 3):
                     entryNum, byte_next = self._read_aedr_fast(byte_loc)
                 else:
@@ -1080,46 +1012,46 @@ class CDF(object):
                 else:
                     aedr_info = self._read_aedr2(byte_loc, to_np=to_np)
                 entryData = aedr_info['entry']
-                if (expand == False):
+                if not expand:
                     return_dict[adr_info['name']] = entryData
                 else:
                     entryWithType = []
-                    if (isinstance(entryData, str)):
+                    if isinstance(entryData, str):
                         entryWithType.append(entryData)
                     else:
                         dataType = aedr_info['data_type']
-                        if (dataType != 31 and dataType != 32 and dataType != 33):
-                            if (len(entryData.tolist()) == 1):
+                        if dataType not in (31, 32, 33):
+                            if len(entryData.tolist()) == 1:
                                 entryWithType.append(entryData.tolist()[0])
                             else:
                                 entryWithType.append(entryData.tolist())
                         else:
-                            if (len(entryData.tolist()) == 1):
-                                if (dataType != 33):
-                                    entryWithType.append(epoch.CDFepoch.encode(entryData.tolist()[0],
-                                                                               iso_8601=False))
+                            if len(entryData.tolist()) == 1:
+                                if dataType != 33:
+                                    entryWithType.append(CDFepoch.encode(entryData.tolist()[0], iso_8601=False))   # type: ignore
                                 else:
-                                    entryWithType.append(epoch.CDFepoch.encode(entryData.tolist()[0]))
+                                    entryWithType.append(CDFepoch.encode(entryData.tolist()[0]))   # type: ignore
                             else:
-                                if (dataType != 33):
-                                    entryWithType.append(epoch.CDFepoch.encode(entryData.tolist(),
-                                                                               iso_8601=False))
+                                if dataType != 33:
+                                    entryWithType.append(CDFepoch.encode(entryData.tolist(),  iso_8601=False))   # type: ignore
                                 else:
-                                    entryWithType.append(epoch.CDFepoch.encode(entryData.tolist()))
-                    entryWithType.append(CDF._datatype_token(aedr_info['data_type']))
+                                    entryWithType.append(CDFepoch.encode(entryData.tolist()))   # type: ignore
+                    entryWithType.append(_datatype_token(aedr_info['data_type']))
                     return_dict[adr_info['name']] = entryWithType
                 found = 1
                 break
             byte_loc = adr_info['next_adr_location']
-            if (found == 0 and expand != False):
+            if found == 0 and expand:
                 return_dict[adr_info['name']] = None
+
         return return_dict
 
-    def _read_adr(self, byte_loc):
+    def _read_adr(self, byte_loc: int) -> Dict[str, Any]:
         with self.file.open('rb') as f:
             f.seek(byte_loc, 0)
             block_size = int.from_bytes(f.read(8), 'big')  # Block Size
             adr = f.read(block_size-8)
+
         next_adr_loc = int.from_bytes(adr[4:12], 'big', signed=True)
         position_next_gr_entry = int.from_bytes(adr[12:20], 'big', signed=True)
         scope = int.from_bytes(adr[20:24], 'big', signed=True)
@@ -1144,11 +1076,11 @@ class CDF(object):
         return_dict['max_z_entry'] = MaxZEntry
         return_dict['first_z_entry'] = position_next_z_entry
         return_dict['first_gr_entry'] = position_next_gr_entry
-        return_dict['name'] = name
+        return_dict['name'] = name  # type: ignore
 
         return return_dict
 
-    def _read_adr2(self, byte_loc):
+    def _read_adr2(self, byte_loc: int) -> Dict[str, Any]:
         with self.file.open('rb') as f:
             f.seek(byte_loc, 0)
             block_size = int.from_bytes(f.read(4), 'big')  # Block Size
@@ -1178,11 +1110,11 @@ class CDF(object):
         return_dict['max_z_entry'] = MaxZEntry
         return_dict['first_z_entry'] = position_next_z_entry
         return_dict['first_gr_entry'] = position_next_gr_entry
-        return_dict['name'] = name
+        return_dict['name'] = name  # type: ignore
 
         return return_dict
 
-    def _read_adr_fast(self, byte_loc):
+    def _read_adr_fast(self, byte_loc: int) -> Tuple[str, int]:
         with self.file.open('rb') as f:
             # Position of next ADR
             f.seek(byte_loc+12, 0)
@@ -1195,7 +1127,7 @@ class CDF(object):
 
         return name, next_adr_loc
 
-    def _read_adr_fast2(self, byte_loc):
+    def _read_adr_fast2(self, byte_loc: int) -> Tuple[str, int]:
         with self.file.open('rb') as f:
             # Position of next ADR
             f.seek(byte_loc+8, 0)
@@ -1208,7 +1140,7 @@ class CDF(object):
 
         return name, next_adr_loc
 
-    def _read_aedr_fast(self, byte_loc):
+    def _read_aedr_fast(self, byte_loc: int) -> Tuple[int, int]:
         with self.file.open('rb') as f:
             f.seek(byte_loc+12, 0)
             next_aedr = int.from_bytes(f.read(8), 'big', signed=True)
@@ -1219,7 +1151,7 @@ class CDF(object):
 
         return entry_num, next_aedr
 
-    def _read_aedr_fast2(self, byte_loc):
+    def _read_aedr_fast2(self, byte_loc: int) -> Tuple[int, int]:
         with self.file.open('rb') as f:
             f.seek(byte_loc+8, 0)
             next_aedr = int.from_bytes(f.read(4), 'big', signed=True)
@@ -1230,7 +1162,7 @@ class CDF(object):
 
         return entry_num, next_aedr
 
-    def _read_aedr(self, byte_loc, to_np=True):
+    def _read_aedr(self, byte_loc: int, to_np: bool=True) -> Dict[str, Any]:
         '''
         Reads an Attribute Entry Descriptor Record at a specific byte location.
 
@@ -1280,11 +1212,12 @@ class CDF(object):
 
         return return_dict
 
-    def _read_aedr2(self, byte_loc, to_np=True):
-        f = self.file
-        f.seek(byte_loc, 0)
-        block_size = int.from_bytes(f.read(4), 'big')
-        aedr = f.read(block_size-4)
+    def _read_aedr2(self, byte_loc: int, to_np: bool=True) -> Dict[str, Any]:
+        with self.file.open('rb') as f:
+            f.seek(byte_loc, 0)
+            block_size = int.from_bytes(f.read(4), 'big')
+            aedr = f.read(block_size-4)
+
         next_aedr = int.from_bytes(aedr[4:8], 'big', signed=True)
         data_type = int.from_bytes(aedr[12:16], 'big', signed=True)
 
@@ -1297,17 +1230,19 @@ class CDF(object):
         if to_np:
             entry = self._read_data(byte_stream, data_type, 1, num_elements)
         else:
-            if (data_type == 32):
+            if data_type == 32:
                 entry = self._convert_data(byte_stream, data_type, 1, 2, num_elements)
             else:
                 entry = self._convert_data(byte_stream, data_type, 1, 1, num_elements)
+
         return_dict = {}
         return_dict['entry'] = entry
         return_dict['data_type'] = data_type
         return_dict['num_elements'] = num_elements
-        #return_dict['num_strings'] = num_strings
+        # return_dict['num_strings'] = num_strings
         return_dict['next_aedr'] = next_aedr
         return_dict['entry_num'] = entry_num
+
         return return_dict
 
     def _read_vdr(self, byte_loc):
@@ -1344,17 +1279,17 @@ class CDF(object):
         if (section_type == 8):
             # zvariable
             num_dims = int.from_bytes(vdr[332:336], 'big', signed=True)
-            for x in range(0, num_dims):
+            for x in range(num_dims):
                 ioff = 336 + 4 * x
                 zdim_sizes.append(int.from_bytes(vdr[ioff:ioff+4], 'big',
                                                  signed=True))
             coff = 336 + 4 * num_dims
-            for x in range(0, num_dims):
+            for x in range(num_dims):
                 dim_varys.append(int.from_bytes(vdr[coff+4*x:coff+4*x+4],
                                                 'big', signed=True))
             adj = 0
             # Check for "False" dimensions, and delete them
-            for x in range(0, num_dims):
+            for x in range(num_dims):
                 y = num_dims - x - 1
                 if (dim_varys[y] == 0):
                     del zdim_sizes[y]
@@ -1364,11 +1299,11 @@ class CDF(object):
             coff = 336 + 8 * num_dims
         else:
             # rvariable
-            for x in range(0, self._rvariables_num_dims):
+            for x in range(self._rvariables_num_dims):
                 ioff = 332 + 4 * x
                 dim_varys.append(int.from_bytes(vdr[ioff:ioff+4], 'big',
                                                 signed=True))
-            for x in range(0, self._rvariables_num_dims):
+            for x in range(self._rvariables_num_dims):
                 if (dim_varys[x] != 0):
                     dim_sizes.append(self._rvariables_dim_sizes[x])
             num_dims = len(dim_sizes)
@@ -1412,7 +1347,7 @@ class CDF(object):
 
     def _read_vdr2(self, byte_loc):
 
-        if (self._post25 == True):
+        if self._post25:
             toadd = 0
         else:
             toadd = 128
@@ -1449,12 +1384,12 @@ class CDF(object):
             # zvariable
             num_dims = int.from_bytes(vdr[124+toadd:128+toadd], 'big',
                                       signed=True)
-            for x in range(0, num_dims):
+            for x in range(num_dims):
                 xoff = 128 + toadd + 4*x
                 zdim_sizes.append(int.from_bytes(vdr[xoff:xoff+4], 'big',
                                                  signed=True))
             coff = 128 + toadd + 4 * num_dims
-            for x in range(0, num_dims):
+            for x in range(num_dims):
                 icoff = coff + 4 * x
                 if (int.from_bytes(vdr[icoff:icoff+4], 'big', signed=True) == 0):
                     dim_varys.append(False)
@@ -1462,9 +1397,9 @@ class CDF(object):
                     dim_varys.append(True)
             adj = 0
             # Check for "False" dimensions, and delete them
-            for x in range(0, num_dims):
+            for x in range(num_dims):
                 y = num_dims - x - 1
-                if (dim_varys[y] == 0 or dim_varys[y] == False):
+                if dim_varys[y] == 0 or not dim_varys[y]:
                     del zdim_sizes[y]
                     del dim_varys[y]
                     adj = adj + 1
@@ -1472,13 +1407,13 @@ class CDF(object):
             coff = 128 + toadd + 8 * num_dims
         else:
             # rvariable
-            for x in range(0, self._rvariables_num_dims):
+            for x in range(self._rvariables_num_dims):
                 ix = 124 + toadd + 4 * x
                 if (int.from_bytes(vdr[ix:ix+4], 'big', signed=True) == 0):
                     dim_varys.append(False)
                 else:
                     dim_varys.append(True)
-            for x in range(0, len(dim_varys)):
+            for x in range(len(dim_varys)):
                 dim_sizes.append(self._rvariables_dim_sizes[x])
             num_dims = len(dim_sizes)
             coff = 124 + toadd + 4 * self._rvariables_num_dims
@@ -1487,7 +1422,7 @@ class CDF(object):
             byte_stream = vdr[coff:]
             try:
                 pad = self._read_data(byte_stream, data_type, 1, num_elements)
-            except:
+            except Exception:
                 if (data_type == 51 or data_type == 52):
                     pad = ' '*num_elements
 
@@ -1561,7 +1496,7 @@ class CDF(object):
             num_ent = int.from_bytes(vxrs[12:16], 'big', signed=True)
             num_ent_used = int.from_bytes(vxrs[16:20], 'big', signed=True)
             # coff = 20
-            for ix in range(0, num_ent_used):
+            for ix in range(num_ent_used):
                 soffset = 20 + 4 * ix
                 num_start = int.from_bytes(vxrs[soffset:soffset+4], 'big',
                                            signed=True)
@@ -1597,7 +1532,7 @@ class CDF(object):
         num_ent = int.from_bytes(vxrs[8:12], 'big', signed=True)
         num_ent_used = int.from_bytes(vxrs[12:16], 'big', signed=True)
         # coff = 16
-        for ix in range(0, num_ent_used):
+        for ix in range(num_ent_used):
             soffset = 16 + 4 * ix
             num_start = int.from_bytes(vxrs[soffset:soffset+4], 'big',
                                        signed=True)
@@ -1629,8 +1564,8 @@ class CDF(object):
         Decodes the byte_stream, then returns them.
         '''
 
-        numBytes = CDF._type_size(vdr_dict['data_type'],
-                                  vdr_dict['num_elements'])
+        numBytes = _type_size(vdr_dict['data_type'],
+                              vdr_dict['num_elements'])
         numValues = self._num_values(vdr_dict)
         totalRecs = endrec - startrec + 1
         firstBlock = -1
@@ -1639,7 +1574,7 @@ class CDF(object):
         byte_stream = bytearray(totalBytes)
         pos = 0
         if (vdr_dict['sparse'] == 0):
-            for vvr_num in range(0, len(vvr_offs)):
+            for vvr_num in range(len(vvr_offs)):
                 if (vvr_end[vvr_num] >= startrec and firstBlock == -1):
                     firstBlock = vvr_num
                 if (vvr_end[vvr_num] >= endrec):
@@ -1660,20 +1595,20 @@ class CDF(object):
             # with sparse records
             if ('pad' in vdr_dict):
                 # use default pad value
-                filled_data = CDF._convert_np_data(vdr_dict['pad'],
-                                                   vdr_dict['data_type'],
-                                                   vdr_dict['num_elements'])
+                filled_data = _convert_np_data(vdr_dict['pad'],
+                                               vdr_dict['data_type'],
+                                               vdr_dict['num_elements'])
             else:
-                filled_data = CDF._convert_np_data(
-                    self._default_pad(vdr_dict['data_type'], 
+                filled_data = _convert_np_data(
+                    self._default_pad(vdr_dict['data_type'],
                                       vdr_dict['num_elements']),
                     vdr_dict['data_type'],
                     vdr_dict['num_elements'])
             cur_block = -1
             rec_size = numBytes * numValues
             for rec_num in range(startrec, (endrec+1)):
-                block, prev_block = CDF._find_block(vvr_start, vvr_end,
-                                                    cur_block, rec_num)
+                block, prev_block = _find_block(vvr_start, vvr_end,
+                                                cur_block, rec_num)
                 if (block > -1):
                     record_off = rec_num - vvr_start[block]
                     if (cur_block != block):
@@ -1709,7 +1644,7 @@ class CDF(object):
         dimensions = []
         var_vary = vdr_dict['dim_vary']
         var_sizes = vdr_dict['dim_sizes']
-        for x in range(0, vdr_dict['num_dims']):
+        for x in range(vdr_dict['num_dims']):
             if (var_vary[x] == 0):
                 continue
             dimensions.append(var_sizes[x])
@@ -1751,73 +1686,10 @@ class CDF(object):
         Determines endianess of the CDF file
         Only used in __init__
         '''
-        if (self._encoding == 1 or self._encoding == 2 or self._encoding == 5 or
-            self._encoding == 7 or self._encoding == 9 or self._encoding == 11 or
-                self._encoding == 12):
+        if self._encoding in (1, 2, 5, 7, 9, 11, 12):
             return 'big-endian'
         else:
             return 'little-endian'
-
-    def _type_size(data_type, num_elms):  # @NoSelf
-        # DATA TYPES
-        #
-        # 1 - 1 byte signed int
-        # 2 - 2 byte signed int
-        # 4 - 4 byte signed int
-        # 8 - 8 byte signed int
-        # 11 - 1 byte unsigned int
-        # 12 - 2 byte unsigned int
-        # 14 - 4 byte unsigned int
-        # 41 - same as 1
-        # 21 - 4 byte float
-        # 22 - 8 byte float (double)
-        # 44 - same as 21
-        # 45 - same as 22
-        # 31 - double representing milliseconds
-        # 32 - 2 doubles representing milliseconds
-        # 33 - 8 byte signed integer representing nanoseconds from J2000
-        # 51 - signed character
-        # 52 - unsigned character
-
-        if (isinstance(data_type, int)):
-            if ((data_type == 1) or (data_type == 11) or (data_type == 41)):
-                return 1
-            elif ((data_type == 2) or (data_type == 12)):
-                return 2
-            elif ((data_type == 4) or (data_type == 14)):
-                return 4
-            elif ((data_type == 8) or (data_type == 33)):
-                return 8
-            elif ((data_type == 21) or (data_type == 44)):
-                return 4
-            elif ((data_type == 22) or (data_type == 31) or (data_type == 45)):
-                return 8
-            elif (data_type == 32):
-                return 16
-            elif ((data_type == 51) or (data_type == 52)):
-                return num_elms
-        elif (isinstance(data_type, str)):
-            data_typeU = data_type.upper()
-            if ((data_typeU == 'CDF_INT1') or (data_typeU == 'CDF_UINT1') or
-                    (data_typeU == 'CDF_BYTE')):
-                return 1
-            elif ((data_typeU == 'CDF_INT2') or (data_typeU == 'CDF_UINT2')):
-                return 2
-            elif ((data_typeU == 'CDF_INT4') or (data_typeU == 'CDF_UINT4')):
-                return 4
-            elif ((data_typeU == 'CDF_INT8') or (data_typeU == 'CDF_TIME_TT2000')):
-                return 8
-            elif ((data_typeU == 'CDF_REAL4') or (data_typeU == 'CDF_FLOAT')):
-                return 4
-            elif ((data_typeU == 'CDF_REAL8') or (data_typeU == 'CDF_DOUBLE') or
-                  (data_typeU == 'CDF_EPOCH')):
-                return 8
-            elif (data_typeU == 'CDF_EPOCH16'):
-                return 16
-            elif ((data_typeU == 'CDF_CHAR') or (data_typeU == 'CDF_UCHAR')):
-                return num_elms
-        else:
-            raise TypeError('Unknown data type....')
 
     def _read_data(self, byte_stream, data_type, num_recs, num_elems, dimensions=None):
         '''
@@ -1832,7 +1704,7 @@ class CDF(object):
         # for the numpy dtype.  This requires us to squeeze
         # the matrix later, to get rid of this extra dimension.
         dt_string = self._convert_option()
-        if dimensions != None:
+        if dimensions is not None:
             if (len(dimensions) == 1):
                 dimensions.append(1)
                 squeeze_needed = True
@@ -1846,11 +1718,11 @@ class CDF(object):
             dt_string += ')'
         if data_type == 52 or data_type == 51:
             # string
-            if dimensions == None:
+            if dimensions is None:
                 byte_data = bytearray(byte_stream[0:num_recs*num_elems])
                 # In each record, check for the first '\x00' (null character).
                 # If found, make all the characters after it null as well.
-                for x in range(0, num_recs):
+                for x in range(num_recs):
                     y = x * num_elems
                     z = byte_data[y:y+num_elems].find(b'\x00')
                     if (z > -1 and z < (num_elems-1)):
@@ -1859,7 +1731,7 @@ class CDF(object):
             else:
                 # Count total number of strings
                 count = 1
-                for x in range(0, len(dimensions)):
+                for x in range(len(dimensions)):
                     count = count * dimensions[x]
                 strings = []
                 if (len(dimensions) == 0):
@@ -1868,7 +1740,7 @@ class CDF(object):
                             replace('\x00', '')
                         strings.append(string1)
                 else:
-                    for x in range(0, num_recs):
+                    for x in range(num_recs):
                         onerec = []
                         for i in range(x*count*num_elems, (x+1)*count*num_elems,
                                        num_elems):
@@ -1912,21 +1784,23 @@ class CDF(object):
 
         return ret
 
-    def _num_values(self, vdr_dict):
+    def _num_values(self, vdr_dict: dict):
         '''
         Returns the number of values in a record, using a given VDR
         dictionary. Multiplies the dimension sizes of each dimension,
         if it is varying.
         '''
         values = 1
-        for x in range(0, vdr_dict['num_dims']):
+        for x in range(vdr_dict['num_dims']):
             if (vdr_dict['dim_vary'][x] != 0):
                 values = values * vdr_dict['dim_sizes'][x]
+
         return values
 
-    def _get_attdata(self, adr_info, entry_num, num_entry, first_entry, to_np=True):
+    def _get_attdata(self, adr_info, entry_num: int,
+                     num_entry: int, first_entry: int, to_np: bool=True) -> Dict[str, Any]:
         position = first_entry
-        for _ in range(0, num_entry):
+        for _ in range(num_entry):
             if (self.cdfversion == 3):
                 got_entry_num, next_aedr = self._read_aedr_fast(position)
             else:
@@ -1936,10 +1810,11 @@ class CDF(object):
                     aedr_info = self._read_aedr(position, to_np=to_np)
                 else:
                     aedr_info = self._read_aedr2(position, to_np=to_np)
+
                 return_dict = {}
-                return_dict['Item_Size'] = CDF._type_size(aedr_info['data_type'],
-                                                          aedr_info['num_elements'])
-                return_dict['Data_Type'] = CDF._datatype_token(aedr_info['data_type'])
+                return_dict['Item_Size'] = _type_size(aedr_info['data_type'],
+                                                      aedr_info['num_elements'])
+                return_dict['Data_Type'] = _datatype_token(aedr_info['data_type'])  # type: ignore
 
                 return_dict['Num_Items'] = aedr_info['num_elements']
                 return_dict['Data'] = aedr_info['entry']
@@ -1948,8 +1823,7 @@ class CDF(object):
                     if (aedr_info['num_strings'] > 1):
                         return_dict['Data'] = aedr_info['entry'].split('\\N ')
                 if not to_np and (aedr_info['data_type'] == 32):
-                    return_dict['Data'] = complex(aedr_info['entry'][0],
-                                                  aedr_info['entry'][1])
+                    return_dict['Data'] = complex(aedr_info['entry'][0], aedr_info['entry'][1])  # type: ignore
                 return return_dict
             else:
                 position = next_aedr
@@ -1957,22 +1831,21 @@ class CDF(object):
         raise KeyError('The entry does not exist')
 
     def _read_vardata(self, vdr_info, epoch=None, starttime=None, endtime=None,
-                      startrec=0, endrec=None, record_range_only=False,
-                      expand=False, to_np=True):
+                      startrec=0, endrec=None, record_range_only: bool=False,
+                      expand: bool=False, to_np: bool=True):
 
         # Error checking
         if startrec:
-            if (startrec < 0):
-                print('Invalid start recond')
-                return None
+            if startrec < 0:
+                raise IndexError('Invalid start recond')
+
             if not (vdr_info['record_vary']):
                 startrec = 0
 
         if not (endrec is None):
-            if ((endrec < 0) or (endrec > vdr_info['max_records']) or
-                    (endrec < startrec)):
-                print('Invalid end recond')
-                return None
+            if (endrec < 0 or endrec > vdr_info['max_records'] or endrec < startrec):
+                raise IndexError('Invalid end recond')
+
             if not (vdr_info['record_vary']):
                 endrec = 0
         else:
@@ -1986,12 +1859,10 @@ class CDF(object):
 
         if (vdr_info['record_vary']):
             # Record varying
-            if (starttime != None or endtime != None):
+            if starttime is not None or endtime is not None:
                 recs = self._findtimerecords(vdr_info['name'], starttime,
                                              endtime, epoch=epoch)
-                if recs is None:
-                    return None
-                if len(recs) == 0:
+                if recs is None or len(recs) == 0:
                     return None
                 else:
                     startrec = recs[0]
@@ -2010,14 +1881,14 @@ class CDF(object):
             new_dict['Rec_Shape'] = vdr_info['dim_sizes']
             new_dict['Num_Records'] = vdr_info['max_records'] + 1
             new_dict['Records_Returned'] = endrec-startrec
-            new_dict['Item_Size'] = CDF._type_size(vdr_info['data_type'],
-                                                   vdr_info['num_elements'])
-            new_dict['Data_Type'] = CDF._datatype_token(vdr_info['data_type'])
+            new_dict['Item_Size'] = _type_size(vdr_info['data_type'],
+                                               vdr_info['num_elements'])
+            new_dict['Data_Type'] = _datatype_token(vdr_info['data_type'])
             new_dict['Data'] = data
             if (vdr_info['sparse']):
                 blocks = len(vvr_start)
                 physical_recs = []
-                for x in range(0, blocks):
+                for x in range(blocks):
                     for y in range(vvr_start[x], vvr_end[x]+1):
                         physical_recs.append(y)
                 new_dict['Real_Records'] = physical_recs
@@ -2030,11 +1901,11 @@ class CDF(object):
 
     def _findtimerecords(self, var_name, starttime, endtime, epoch=None):
 
-        if (epoch != None):
+        if epoch is not None:
             vdr_info = self.varinq(epoch)
-            if (vdr_info == None):
-                print('Epoch not found')
-                return None
+            if vdr_info is None:
+                raise LookupError('Epoch not found')
+
             if (vdr_info['Data_Type'] == 31 or vdr_info['Data_Type'] == 32 or
                     vdr_info['Data_Type'] == 33):
                 epochtimes = self.varget(epoch)
@@ -2046,58 +1917,21 @@ class CDF(object):
             else:
                 # acquire depend_0 variable
                 dependVar = self.attget('DEPEND_0', var_name)
-                if (dependVar == None):
-                    print('No corresponding epoch from \'DEPEND_0\' attribute ',
-                          'for variable:', var_name)
-                    print('Use \'epoch\' argument to specify its time-based variable')
-                    return None
+
+                if dependVar is None:
+                    raise LookupError('No corresponding epoch from "DEPEND_0" attribute for '
+                                      'variable {}.  Use "epoch" argument to specify its time-based variable'.format(var_name))
+
                 vdr_info = self.varinq(dependVar['Data'])
-                if (vdr_info['Data_Type'] != 31 and vdr_info['Data_Type'] != 32
-                        and vdr_info['Data_Type'] != 33):
-                    print('Corresponding variable from \'DEPEND_0\' attribute ',
-                          'for variable:', var_name, ' is not a CDF epoch type')
-                    return None
+
+                if vdr_info['Data_Type'] not in (31, 32, 33):
+                    raise LookupError('Corresponding variable from "DEPEND_0" attribute for variable:'
+                                      ' {} is not a CDF epoch type'.format(var_name))
+
                 epochtimes = self.varget(dependVar['Data'])
 
-        return self._findrangerecords(vdr_info['Data_Type'], epochtimes,
-                                      starttime, endtime)
-
-    def _findrangerecords(self, data_type, epochtimes, starttime, endtime):
-        if (data_type == 31 or data_type == 32 or data_type == 33):
-            #CDF_EPOCH or CDF_EPOCH16 or CDF_TIME_TT2000
-            recs = epoch.CDFepoch.findepochrange(epochtimes, starttime, endtime)
-        else:
-            print('Not a CDF epoch type...')
-            return None
-        return recs
-
-    def _convert_type(self, data_type):
-        '''
-        CDF data types to python struct data types
-        '''
-        if (data_type == 1) or (data_type == 41):
-            dt_string = 'b'
-        elif data_type == 2:
-            dt_string = 'h'
-        elif data_type == 4:
-            dt_string = 'i'
-        elif (data_type == 8) or (data_type == 33):
-            dt_string = 'q'
-        elif data_type == 11:
-            dt_string = 'B'
-        elif data_type == 12:
-            dt_string = 'H'
-        elif data_type == 14:
-            dt_string = 'I'
-        elif (data_type == 21) or (data_type == 44):
-            dt_string = 'f'
-        elif (data_type == 22) or (data_type == 45) or (data_type == 31):
-            dt_string = 'd'
-        elif (data_type == 32):
-            dt_string = 'd'
-        elif (data_type == 51) or (data_type == 52):
-            dt_string = 's'
-        return dt_string
+        return _findrangerecords(vdr_info['Data_Type'], epochtimes,
+                                 starttime, endtime)
 
     def _default_pad(self, data_type, num_elms):   # @NoSelf
         '''
@@ -2130,7 +1964,7 @@ class CDF(object):
         elif (data_type == 21) or (data_type == 44):
             pad_value = struct.pack(order+'f', -1.0E30)
             dt_string = 'f'
-        elif (data_type == 22) or (data_type == 45) or (data_type == 31):
+        elif data_type in (22, 45, 31):
             pad_value = struct.pack(order+'d', -1.0E30)
             dt_string = 'd'
         else:
@@ -2143,23 +1977,7 @@ class CDF(object):
         ret.setflags('WRITEABLE')
         return ret
 
-    def _convert_np_data(data, data_type, num_elems):   # @NoSelf
-        '''
-        Converts a single np data into byte stream.
-        '''
-        if (data_type == 51 or data_type == 52):
-            if (data == ''):
-                return ('\x00'*num_elems).encode()
-            else:
-                return data.ljust(num_elems, '\x00').encode('utf-8')
-        elif (data_type == 32):
-            data_stream = data.real.tobytes()
-            data_stream += data.imag.tobytes()
-            return data_stream
-        else:
-            return data.tobytes()
-
-    def _read_vvr_block(self, offset):
+    def _read_vvr_block(self, offset: int):
         '''
         Returns a VVR or decompressed CVVR block
         '''
@@ -2176,7 +1994,7 @@ class CDF(object):
             # a VVR
             return block[4:]
 
-    def _read_vvr_block2(self, offset):
+    def _read_vvr_block2(self, offset: int):
         '''
         Returns a VVR or decompressed CVVR block
         '''
@@ -2193,44 +2011,241 @@ class CDF(object):
             # a VVR
             return block[4:]
 
-    def _find_block(starts, ends, cur_block, rec_num):   # @NoSelf
-        '''
-        Finds the block that rec_num is in if it is found. Otherwise it returns -1.
-        It also returns the block that has the physical data either at or
-        preceeding the rec_num.
-        It could be -1 if the preceeding block does not exists.
-        '''
-        total = len(starts)
-        if (cur_block == -1):
-            cur_block = 0
-        for x in range(cur_block, total):
-            if (starts[x] <= rec_num and ends[x] >= rec_num):
-                return x, x
-            if (starts[x] > rec_num):
-                break
-        return -1, x-1
-
-    def _convert_data(self, data, data_type, num_recs, num_values, num_elems):
+    def _convert_data(self, data, data_type: int,
+                      num_recs: int, num_values: int, num_elems: int) -> list:
         '''
         Converts data to the appropriate type using the struct.unpack method,
         rather than using numpy.
         '''
 
-        if (data_type == 51 or data_type == 52):
+        if data_type in (51, 52):
             return [data[i:i+num_elems].decode('utf-8') for i in
                     range(0, num_recs*num_values*num_elems, num_elems)]
         else:
             tofrom = self._convert_option()
-            dt_string = self._convert_type(data_type)
+            dt_string = _convert_type(data_type)
             form = tofrom + str(num_recs*num_values*num_elems) + dt_string
-            value_len = CDF._type_size(data_type, num_elems)
+            value_len = _type_size(data_type, num_elems)
             return list(struct.unpack_from(form,
                                            data[0:num_recs*num_values*value_len]))
 
-    def getVersion():   # @NoSelf
+    def getVersion(self):
         """
         Shows the code version and last modified date.
         """
-        print('CDFread version:', str(CDF.version) + '.' + str(CDF.release) +
-              '.' + str(CDF.increment))
+        print('CDFread version: {}.{}.{}'.format(self.version, self.release, self.increment))
         print('Date: 2018/01/11')
+
+
+def _findrangerecords(data_type: int, epochtimes, starttime, endtime):
+    if data_type in (31, 32, 33):
+        # CDF_EPOCH or CDF_EPOCH16 or CDF_TIME_TT2000
+        recs = epoch.CDFepoch.findepochrange(epochtimes, starttime, endtime)
+    else:
+        raise TypeError('Not a CDF epoch type...')
+
+    return recs
+
+
+def _encoding_token(encoding: int) -> str:
+    encodings = {1: 'NETWORK',
+                 2: 'SUN',
+                 3: 'VAX',
+                 4: 'DECSTATION',
+                 5: 'SGi',
+                 6: 'IBMPC',
+                 7: 'IBMRS',
+                 9: 'PPC',
+                 11: 'HP',
+                 12: 'NeXT',
+                 13: 'ALPHAOSF1',
+                 14: 'ALPHAVMSd',
+                 15: 'ALPHAVMSg',
+                 16: 'ALPHAVMSi'}
+
+    return encodings[encoding]
+
+
+def _major_token(major: int) -> str:
+    majors = {1: 'Row_major',
+              2: 'Column_major'}
+
+    return majors[major]
+
+
+def _scope_token(scope: int) -> str:
+    scopes = {1: 'Global',
+              2: 'Variable'}
+
+    return scopes[scope]
+
+
+def _variable_token(variable: int) -> str:
+    variables = {3: 'rVariable',
+                 8: 'zVariable'}
+
+    return variables[variable]
+
+
+def _datatype_token(datatype: int) -> str:
+
+    datatypes = {1: 'CDF_INT1',
+                 2: 'CDF_INT2',
+                 4: 'CDF_INT4',
+                 8: 'CDF_INT8',
+                 11: 'CDF_UINT1',
+                 12: 'CDF_UINT2',
+                 14: 'CDF_UINT4',
+                 21: 'CDF_REAL4',
+                 22: 'CDF_REAL8',
+                 31: 'CDF_EPOCH',
+                 32: 'CDF_EPOCH16',
+                 33: 'CDF_TIME_TT2000',
+                 41: 'CDF_BYTE',
+                 44: 'CDF_FLOAT',
+                 45: 'CDF_DOUBLE',
+                 51: 'CDF_CHAR',
+                 52: 'CDF_UCHAR'}
+
+    return datatypes[datatype]
+
+
+def _sparse_token(sparse: int) -> str:
+
+    sparses = {0: 'No_sparse',
+               1: 'Pad_sparse',
+               2: 'Prev_sparse'}
+
+    return sparses[sparse]
+
+
+def _convert_np_data(data, data_type: int, num_elems: int):
+    '''
+    Converts a single np data into byte stream.
+    '''
+    if data_type in (51, 52):
+        if (data == ''):
+            return ('\x00'*num_elems).encode()
+        else:
+            return data.ljust(num_elems, '\x00').encode('utf-8')
+    elif data_type == 32:
+        data_stream = data.real.tobytes()
+        data_stream += data.imag.tobytes()
+        return data_stream
+    else:
+        return data.tobytes()
+
+
+def _convert_type(data_type: int) -> str:
+    '''
+    CDF data types to python struct data types
+    '''
+    if data_type in (1, 41):
+        dt_string = 'b'
+    elif data_type == 2:
+        dt_string = 'h'
+    elif data_type == 4:
+        dt_string = 'i'
+    elif data_type in (8, 33):
+        dt_string = 'q'
+    elif data_type == 11:
+        dt_string = 'B'
+    elif data_type == 12:
+        dt_string = 'H'
+    elif data_type == 14:
+        dt_string = 'I'
+    elif data_type in (21, 44):
+        dt_string = 'f'
+    elif data_type in (22, 45, 31):
+        dt_string = 'd'
+    elif data_type == 32:
+        dt_string = 'd'
+    elif data_type in (51, 52):
+        dt_string = 's'
+    else:
+        raise ValueError('data_type must be integer')
+
+    return dt_string
+
+
+def _find_block(starts: Sequence[int], ends: Sequence[int],
+                cur_block: int, rec_num: int) -> Tuple[int, int]:
+    '''
+    Finds the block that rec_num is in if it is found. Otherwise it returns -1.
+    It also returns the block that has the physical data either at or
+    preceeding the rec_num.
+    It could be -1 if the preceeding block does not exists.
+    '''
+    total = len(starts)
+    if (cur_block == -1):
+        cur_block = 0
+    for x in range(cur_block, total):
+        if (starts[x] <= rec_num and ends[x] >= rec_num):
+            return x, x
+        if (starts[x] > rec_num):
+            break
+    return -1, x-1
+
+
+def _type_size(data_type: Union[int, str], num_elms: int) -> int:
+    """
+    DATA TYPES
+
+    1 - 1 byte signed int
+    2 - 2 byte signed int
+    4 - 4 byte signed int
+    8 - 8 byte signed int
+    11 - 1 byte unsigned int
+    12 - 2 byte unsigned int
+    14 - 4 byte unsigned int
+    41 - same as 1
+    21 - 4 byte float
+    22 - 8 byte float (double)
+    44 - same as 21
+    45 - same as 22
+    31 - double representing milliseconds
+    32 - 2 doubles representing milliseconds
+    33 - 8 byte signed integer representing nanoseconds from J2000
+    51 - signed character
+    52 - unsigned character
+    """
+
+    if isinstance(data_type, int):
+        if data_type in (1, 11, 41):
+            N = 1
+        elif data_type in (2, 12):
+            N = 2
+        elif data_type in (4, 14):
+            N = 4
+        elif data_type in (8, 33):
+            N = 8
+        elif data_type in (21, 44):
+            N = 4
+        elif data_type in (22, 31, 45):
+            N = 8
+        elif data_type == 32:
+            N = 16
+        elif data_type in (51, 52):
+            N = num_elms
+    elif isinstance(data_type, str):
+        data_typeU = data_type.upper()
+        if data_typeU in ('CDF_INT1', 'CDF_UINT1', 'CDF_BYTE'):
+            N = 1
+        elif data_typeU in ('CDF_INT2', 'CDF_UINT2'):
+            N = 2
+        elif data_typeU in ('CDF_INT4', 'CDF_UINT4'):
+            N = 4
+        elif data_typeU in ('CDF_INT8', 'CDF_TIME_TT2000'):
+            N = 8
+        elif data_typeU in ('CDF_REAL4', 'CDF_FLOAT'):
+            N = 4
+        elif data_typeU in ('CDF_REAL8', 'CDF_DOUBLE', 'CDF_EPOCH'):
+            N = 8
+        elif data_typeU == 'CDF_EPOCH16':
+            N = 16
+        elif data_typeU in ('CDF_CHAR', 'CDF_UCHAR'):
+            N = num_elms
+    else:
+        raise TypeError('Unknown data type {}'.format(data_type))
+
+    return N

--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -286,7 +286,7 @@ class CDF(object):
                 print('NAME: ' + name + ', NUMBER: ' + str(x) + ', SCOPE: ' + attrs[x][name])
             return attrs
 
-    def attget(self, attribute=None, entry=None, to_np=True):
+    def attget(self, attribute: Union[str, int]=None, entry=0, to_np=True):
         """
         Returns the value of the attribute at the entry number provided.
 

--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -221,7 +221,25 @@ class CDFepoch:
         else:
             raise TypeError('Bad input')
 
-    def unixtime(self, cdf_time, to_np: bool=False):
+    def to_datetime(self, cdf_time: Sequence[float], to_np: bool=False) -> List[datetime.datetime]:
+        """
+        Encodes the epoch(s) into Python datetime.  Precision is only
+        kept to the nearest microsecond.
+
+        If to_np is True, then the values will be returned in a numpy array.
+        """
+        time_list = self.breakdown(cdf_time, to_np=False)
+
+        if len(time_list[0]) == 8:
+            dt = [datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], microsecond=t[6]*1000+t[7]) for t in time_list]
+        elif len(time_list[0]) == 7:
+            dt = [datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], microsecond=t[6]*1000) for t in time_list]
+        else:
+            raise ValueError('unknown cdf_time format')
+
+        return np.array(dt) if to_np else dt
+
+    def unixtime(self, cdf_time: Sequence[float], to_np: bool=False):
         """
         Encodes the epoch(s) into seconds after 1970-01-01.  Precision is only
         kept to the nearest microsecond.

--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -30,134 +30,134 @@ All these epoch values can come from from CDF.varget function.
 
 @author: Michael Liu
 """
-
+import datetime
 import numpy as np
 import math
 import re
 import numbers
-import os
+from pathlib import Path
+import logging
+import urllib.request
+import csv
+from typing import List, Union, Sequence   # noqa: F401
+
+FILLED_TT2000_VALUE = int(-9223372036854775808)
+DEFAULT_TT2000_PADVALUE = int(-9223372036854775807)
+MONTH_TOKEN = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
 
 class CDFepoch:
 
-    version = 3
-    release = 7
-    increment = 0
+    def __init__(self) -> None:
+        self.version = 3
+        self.release = 7
+        self.increment = 0
 
-    month_Token = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+        self.JulianDateJ2000_12h = 2451545
+        self.J2000Since0AD12h = 730485
+        self.J2000Since0AD12hSec = 63113904000.0
+        self.J2000Since0AD12hMilsec = 63113904000000.0
+        self.J2000LeapSeconds = 32.0
+        self.dT = 32.184
+        self.dTinNanoSecs = 32184000000
+        self.MJDbase = 2400000.5
+        self.SECinNanoSecs = 1000000000
+        self.SECinNanoSecsD = 1000000000.0
+        self.DAYinNanoSecs = int(86400000000000)
+        self.HOURinNanoSecs = int(3600000000000)
+        self.MINUTEinNanoSecs = int(60000000000)
+        self.T12hinNanoSecs = int(43200000000000)
+        # Julian days for 1707-09-22 and 2292-04-11, the valid TT2000 range
+        self.JDY17070922 = 2344793
+        self.JDY22920411 = 2558297
+        self.DEFAULT_TT2000_PADVALUE = DEFAULT_TT2000_PADVALUE
+        self.FILLED_TT2000_VALUE = FILLED_TT2000_VALUE
+        self.NERA1 = 14
 
-    JulianDateJ2000_12h = 2451545
-    J2000Since0AD12h = 730485
-    J2000Since0AD12hSec = 63113904000.0
-    J2000Since0AD12hMilsec = 63113904000000.0
-    J2000LeapSeconds = 32.0
-    dT = 32.184
-    dTinNanoSecs = 32184000000
-    MJDbase = 2400000.5
-    SECinNanoSecs = 1000000000
-    SECinNanoSecsD = 1000000000.0
-    DAYinNanoSecs = int(86400000000000)
-    HOURinNanoSecs = int(3600000000000)
-    MINUTEinNanoSecs = int(60000000000)
-    T12hinNanoSecs = int(43200000000000)
-    # Julian days for 1707-09-22 and 2292-04-11, the valid TT2000 range
-    JDY17070922 = 2344793
-    JDY22920411 = 2558297
-    DEFAULT_TT2000_PADVALUE = int(-9223372036854775807)
-    FILLED_TT2000_VALUE = int(-9223372036854775808)
-    NERA1 = 14
+        # LASTLEAPSECONDDAY = 20170101
+        library_path = Path(__file__).parent
+        leap_sec_file = library_path / 'CDFLeapSeconds.txt'
+        # Attempt to download latest leap second table
+        try:
+            leapsecond_files_url = "https://cdf.gsfc.nasa.gov/html/CDFLeapSeconds.txt"
+            page = urllib.request.urlopen(leapsecond_files_url)
 
-    #LASTLEAPSECONDDAY = 20170101
+            with leap_sec_file.open("wb") as lsfile:
+                lsfile.write(page.read())
+        except Exception:
+            logging.error("Can't download new leap second table")
 
-    # Attempt to download latest leap second table
-    try:
-        import urllib.request
-        leapsecond_files_url = "https://cdf.gsfc.nasa.gov/html/CDFLeapSeconds.txt"
-        page = urllib.request.urlopen(leapsecond_files_url)
-        full_path = os.path.realpath(__file__)
-        library_path = os.path.dirname(full_path)
-        with open(os.path.join(library_path, 'CDFLeapSeconds.txt'), "wb") as lsfile:
-            lsfile.write(page.read())
-    except:
-        print("Can't download new leap second table")
-        pass
+        # Attempt to load the leap second table saved in the cdflib
+        try:
+            self.LTS = []  # type: List[List[Union[int, float]]]
+            with leap_sec_file.open('r') as lsfile:
+                lsreader = csv.reader(lsfile, delimiter=' ')
+                for row in lsreader:
+                    if row[0] == ";":
+                        continue
+                    row = list(filter(('').__ne__, row))
 
-    # Attempt to load the leap second table saved in the cdflib
-    try:
-        import csv
-        full_path = os.path.realpath(__file__)
-        library_path = os.path.dirname(full_path)
-        leap_seconds_file = os.path.join(library_path, 'CDFLeapSeconds.txt')
-        LTS = []
-        with open(leap_seconds_file) as lsfile:
-            lsreader = csv.reader(lsfile, delimiter=' ')
-            for row in lsreader:
-                if row[0] == ";":
-                    continue
-                row = list(filter(('').__ne__, row))
-                row[0] = int(row[0])
-                row[1] = int(row[1])
-                row[2] = int(row[2])
-                row[3] = float(row[3])
-                row[4] = float(row[4])
-                row[5] = float(row[5])
-                LTS.append(row)
-    except:
-        print("Can't find leap second table.  Using one built into code.")
-        print("Last leap second in built in table is on Jan 01 2017. ")
-        # Use a built in leap second table
-        LTS = [[1960,  1,  1,  1.4178180, 37300.0, 0.0012960],
-               [1961,  1,  1,  1.4228180, 37300.0, 0.0012960],
-               [1961,  8,  1,  1.3728180, 37300.0, 0.0012960],
-               [1962,  1,  1,  1.8458580, 37665.0, 0.0011232],
-               [1963, 11,  1,  1.9458580, 37665.0, 0.0011232],
-               [1964,  1,  1,  3.2401300, 38761.0, 0.0012960],
-               [1964,  4,  1,  3.3401300, 38761.0, 0.0012960],
-               [1964,  9,  1,  3.4401300, 38761.0, 0.0012960],
-               [1965,  1,  1,  3.5401300, 38761.0, 0.0012960],
-               [1965,  3,  1,  3.6401300, 38761.0, 0.0012960],
-               [1965,  7,  1,  3.7401300, 38761.0, 0.0012960],
-               [1965,  9,  1,  3.8401300, 38761.0, 0.0012960],
-               [1966,  1,  1,  4.3131700, 39126.0, 0.0025920],
-               [1968,  2,  1,  4.2131700, 39126.0, 0.0025920],
-               [1972,  1,  1, 10.0,           0.0, 0.0],
-               [1972,  7,  1, 11.0,           0.0, 0.0],
-               [1973,  1,  1, 12.0,           0.0, 0.0],
-               [1974,  1,  1, 13.0,           0.0, 0.0],
-               [1975,  1,  1, 14.0,           0.0, 0.0],
-               [1976,  1,  1, 15.0,           0.0, 0.0],
-               [1977,  1,  1, 16.0,           0.0, 0.0],
-               [1978,  1,  1, 17.0,           0.0, 0.0],
-               [1979,  1,  1, 18.0,           0.0, 0.0],
-               [1980,  1,  1, 19.0,           0.0, 0.0],
-               [1981,  7,  1, 20.0,           0.0, 0.0],
-               [1982,  7,  1, 21.0,           0.0, 0.0],
-               [1983,  7,  1, 22.0,           0.0, 0.0],
-               [1985,  7,  1, 23.0,           0.0, 0.0],
-               [1988,  1,  1, 24.0,           0.0, 0.0],
-               [1990,  1,  1, 25.0,           0.0, 0.0],
-               [1991,  1,  1, 26.0,           0.0, 0.0],
-               [1992,  7,  1, 27.0,           0.0, 0.0],
-               [1993,  7,  1, 28.0,           0.0, 0.0],
-               [1994,  7,  1, 29.0,           0.0, 0.0],
-               [1996,  1,  1, 30.0,           0.0, 0.0],
-               [1997,  7,  1, 31.0,           0.0, 0.0],
-               [1999,  1,  1, 32.0,           0.0, 0.0],
-               [2006,  1,  1, 33.0,           0.0, 0.0],
-               [2009,  1,  1, 34.0,           0.0, 0.0],
-               [2012,  7,  1, 35.0,           0.0, 0.0],
-               [2015,  7,  1, 36.0,           0.0, 0.0],
-               [2017,  1,  1, 37.0,           0.0, 0.0]]
+                    self.LTS.append([int(row[0]),
+                                     int(row[1]),
+                                     int(row[2]),
+                                     float(row[3]),
+                                     float(row[4]),
+                                     float(row[5])])
+        except FileNotFoundError:
+            print("Can't find leap second table.  Using one built into code.")
+            print("Last leap second in built in table is on Jan 01 2017. ")
+            # Use a built in leap second table
+            self.LTS = [[1960, 1, 1, 1.4178180, 37300.0, 0.0012960],
+                        [1961, 1, 1, 1.4228180, 37300.0, 0.0012960],
+                        [1961, 8, 1, 1.3728180, 37300.0, 0.0012960],
+                        [1962, 1, 1, 1.8458580, 37665.0, 0.0011232],
+                        [1963, 11, 1, 1.9458580, 37665.0, 0.0011232],
+                        [1964, 1, 1, 3.2401300, 38761.0, 0.0012960],
+                        [1964, 4, 1, 3.3401300, 38761.0, 0.0012960],
+                        [1964, 9, 1, 3.4401300, 38761.0, 0.0012960],
+                        [1965, 1, 1, 3.5401300, 38761.0, 0.0012960],
+                        [1965, 3, 1, 3.6401300, 38761.0, 0.0012960],
+                        [1965, 7, 1, 3.7401300, 38761.0, 0.0012960],
+                        [1965, 9, 1, 3.8401300, 38761.0, 0.0012960],
+                        [1966, 1, 1, 4.3131700, 39126.0, 0.0025920],
+                        [1968, 2, 1, 4.2131700, 39126.0, 0.0025920],
+                        [1972, 1, 1, 10.0, 0.0, 0.0],
+                        [1972, 7, 1, 11.0, 0.0, 0.0],
+                        [1973, 1, 1, 12.0, 0.0, 0.0],
+                        [1974, 1, 1, 13.0, 0.0, 0.0],
+                        [1975, 1, 1, 14.0, 0.0, 0.0],
+                        [1976, 1, 1, 15.0, 0.0, 0.0],
+                        [1977, 1, 1, 16.0, 0.0, 0.0],
+                        [1978, 1, 1, 17.0, 0.0, 0.0],
+                        [1979, 1, 1, 18.0, 0.0, 0.0],
+                        [1980, 1, 1, 19.0, 0.0, 0.0],
+                        [1981, 7, 1, 20.0, 0.0, 0.0],
+                        [1982, 7, 1, 21.0, 0.0, 0.0],
+                        [1983, 7, 1, 22.0, 0.0, 0.0],
+                        [1985, 7, 1, 23.0, 0.0, 0.0],
+                        [1988, 1, 1, 24.0, 0.0, 0.0],
+                        [1990, 1, 1, 25.0, 0.0, 0.0],
+                        [1991, 1, 1, 26.0, 0.0, 0.0],
+                        [1992, 7, 1, 27.0, 0.0, 0.0],
+                        [1993, 7, 1, 28.0, 0.0, 0.0],
+                        [1994, 7, 1, 29.0, 0.0, 0.0],
+                        [1996, 1, 1, 30.0, 0.0, 0.0],
+                        [1997, 7, 1, 31.0, 0.0, 0.0],
+                        [1999, 1, 1, 32.0, 0.0, 0.0],
+                        [2006, 1, 1, 33.0, 0.0, 0.0],
+                        [2009, 1, 1, 34.0, 0.0, 0.0],
+                        [2012, 7, 1, 35.0, 0.0, 0.0],
+                        [2015, 7, 1, 36.0, 0.0, 0.0],
+                        [2017, 1, 1, 37.0, 0.0, 0.0]]
 
-    NDAT = len(LTS)
+        self.NDAT = len(self.LTS)
 
-    NST = None
-    currentDay = -1
-    currentJDay = -1
-    currentLeapSeconds = -1
+        self.NST = None
+        self.currentDay = -1
+        self.currentJDay = -1
+        self.currentLeapSeconds = -1
 
-    def encode(epochs, iso_8601=True):  # @NoSelf
+    def encode(self, epochs, iso_8601: bool=True) -> Union[str, List[str]]:
         """
         Encodes the epoch(s) into UTC string(s).
 
@@ -183,78 +183,60 @@ class CDFepoch:
                 Or, if iso_8601 is set to False,
                 02-Feb-2008 06:08:10.012.014.016
         """
-        if (isinstance(epochs, int) or isinstance(epochs, np.int64)):
-            return CDFepoch.encode_tt2000(epochs, iso_8601)
-        elif (isinstance(epochs, float) or isinstance(epochs, np.float64)):
-            return CDFepoch.encode_epoch(epochs, iso_8601)
-        elif (isinstance(epochs, complex) or isinstance(epochs, np.complex128)):
-            return CDFepoch.encode_epoch16(epochs, iso_8601)
-        elif (isinstance(epochs, list) or isinstance(epochs, np.ndarray)):
-            if (isinstance(epochs[0], int) or isinstance(epochs[0], np.int64)):
-                return CDFepoch.encode_tt2000(epochs, iso_8601)
-            elif (isinstance(epochs[0], float) or
-                  isinstance(epochs[0], np.float64)):
-                return CDFepoch.encode_epoch(epochs, iso_8601)
-            elif (isinstance(epochs[0], complex) or
-                  isinstance(epochs[0], np.complex128)):
-                return CDFepoch.encode_epoch16(epochs, iso_8601)
+        if isinstance(epochs, (int, np.int64)):
+            return self.encode_tt2000(epochs, iso_8601)
+        elif isinstance(epochs, (float, np.float64)):
+            return encode_epoch(epochs, iso_8601)
+        elif isinstance(epochs, (complex, np.complex128)):
+            return encode_epoch16(epochs, iso_8601)
+        elif isinstance(epochs, (list, np.ndarray)):
+            if isinstance(epochs[0], (int,  np.int64)):
+                return self.encode_tt2000(epochs, iso_8601)
+            elif isinstance(epochs[0], (float, np.float64)):
+                return encode_epoch(epochs, iso_8601)
+            elif isinstance(epochs[0], (complex, np.complex128)):
+                return encode_epoch16(epochs, iso_8601)
             else:
-                print('Bad input')
-                return None
+                raise TypeError('Bad input')
         else:
-            print('Bad input')
-            return None
+            raise TypeError('Bad input')
 
-    def breakdown(epochs, to_np=None):  # @NoSelf
+    def breakdown(self, epochs, to_np: bool=False):
 
-        if (isinstance(epochs, int) or isinstance(epochs, np.int64)):
-            return CDFepoch.breakdown_tt2000(epochs, to_np)
-        elif (isinstance(epochs, float) or isinstance(epochs, np.float64)):
-            return CDFepoch.breakdown_epoch(epochs, to_np)
-        elif (isinstance(epochs, complex) or isinstance(epochs, np.complex128)):
-            return CDFepoch.breakdown_epoch16(epochs, to_np)
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
-            if (isinstance(epochs[0], int) or isinstance(epochs[0], np.int64)):
-                return CDFepoch.breakdown_tt2000(epochs, to_np)
-            elif (isinstance(epochs[0], float) or
-                  isinstance(epochs[0], np.float64)):
-                return CDFepoch.breakdown_epoch(epochs, to_np)
-            elif (isinstance(epochs[0], complex) or
-                  isinstance(epochs[0], np.complex128)):
-                return CDFepoch.breakdown_epoch16(epochs, to_np)
+        if isinstance(epochs, (int, np.int64)):
+            return self.breakdown_tt2000(epochs, to_np)
+        elif isinstance(epochs, (float, np.float64)):
+            return breakdown_epoch(epochs, to_np)
+        elif isinstance(epochs, (complex, np.complex128)):
+            return breakdown_epoch16(epochs, to_np)
+        elif isinstance(epochs, (list, tuple, np.ndarray)):
+            if isinstance(epochs[0], (int, np.int64)):
+                return self.breakdown_tt2000(epochs, to_np)
+            elif isinstance(epochs[0], (float, np.float64)):
+                return breakdown_epoch(epochs, to_np)
+            elif isinstance(epochs[0], (complex, np.complex128)):
+                return breakdown_epoch16(epochs, to_np)
             else:
-                print('Bad input')
-                return None
+                raise TypeError('Bad input')
         else:
-            print('Bad input')
-            return None
+            raise TypeError('Bad input')
 
-    def unixtime(cdf_time, to_np=False):  # @NoSelf
+    def unixtime(self, cdf_time, to_np: bool=False):
         """
         Encodes the epoch(s) into seconds after 1970-01-01.  Precision is only
         kept to the nearest microsecond.
 
         If to_np is True, then the values will be returned in a numpy array.
         """
-        import datetime
-        time_list = CDFepoch.breakdown(cdf_time, to_np=False)
-        unixtime = []
-        for t in time_list:
-            date = ['year', 'month', 'day', 'hour', 'minute', 'second', 'microsecond']
-            for i in range(0, len(t)):
-                if i > 7:
-                    continue
-                elif i == 6:
-                    date[i] = 1000*t[i]
-                elif i == 7:
-                    date[i-1] += t[i]
-                else:
-                    date[i] = t[i]
-            unixtime.append(datetime.datetime(*date).replace(tzinfo=datetime.timezone.utc).timestamp())
+        time_list = self.breakdown(cdf_time, to_np=False)
+
+        unixtime = [datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5],
+                                      microsecond=t[6]*1000+t[7]).replace(
+            tzinfo=datetime.timezone.utc).timestamp() for t in time_list]
+
         return np.array(unixtime) if to_np else unixtime
 
-    def compute(datetimes, to_np=None):  # @NoSelf
+    def compute(self, datetimes, to_np: bool=False):
         """
         Computes the provided date/time components into CDF epoch value(s).
 
@@ -290,26 +272,24 @@ class CDFepoch:
 
         if not isinstance(datetimes, (list, tuple, np.ndarray)):
             raise TypeError('datetime must be in list form')
-            
+
         if isinstance(datetimes[0], numbers.Number):
             items = len(datetimes)
         elif isinstance(datetimes[0], (list, tuple, np.ndarray)):
             items = len(datetimes[0])
         else:
-            print('Unknown input')
-            return
-          
-        if (items == 7):
-            return CDFepoch.compute_epoch(datetimes, to_np)
-        elif (items == 10):
-            return CDFepoch.compute_epoch16(datetimes, to_np)
-        elif (items == 9):
-            return CDFepoch.compute_tt2000(datetimes, to_np)
-        else:
-            print('Unknown input')
-            return
+            raise TypeError('Unknown input')
 
-    def findepochrange(epochs, starttime=None, endtime=None):  # @NoSelf
+        if items == 7:
+            return compute_epoch(datetimes, to_np)
+        elif items == 10:
+            return compute_epoch16(datetimes, to_np)
+        elif items == 9:
+            return self.compute_tt2000(datetimes, to_np)
+        else:
+            raise ValueError('Bad input')
+
+    def findepochrange(self, epochs, starttime=None, endtime=None):
         """
         Finds the record range within the start and end time from values
         of a CDF epoch data type. It returns a list of record numbers.
@@ -323,53 +303,48 @@ class CDFepoch:
         The start/end times should be in either be in epoch units, or in the list
         format described in "compute_epoch/epoch16/tt2000" section.
         """
-        if (isinstance(epochs, float) or isinstance(epochs, np.float64)):
-            return CDFepoch.epochrange_epoch(epochs, starttime, endtime)
-        elif (isinstance(epochs, int) or isinstance(epochs, np.int64)):
-            return CDFepoch.epochrange_tt2000(epochs, starttime, endtime)
+        if isinstance(epochs, (float, np.float64)):
+            return self.epochrange_epoch(epochs, starttime, endtime)
+        elif isinstance(epochs, (int, np.int64)):
+            return self.epochrange_tt2000(epochs, starttime, endtime)
         elif isinstance(epochs, (complex, np.complex128)):
-            return CDFepoch.epochrange_epoch16(epochs, starttime, endtime)
+            return self.epochrange_epoch16(epochs, starttime, endtime)
         elif isinstance(epochs, (list, tuple, np.ndarray)):
-            if (isinstance(epochs[0], float) or
-                    isinstance(epochs[0], np.float64)):
-                return CDFepoch.epochrange_epoch(epochs, starttime, endtime)
-            elif (isinstance(epochs[0], int) or
-                  isinstance(epochs[0], np.int64)):
-                return CDFepoch.epochrange_tt2000(epochs, starttime, endtime)
-            elif (isinstance(epochs[0], complex) or
-                  isinstance(epochs[0], np.complex128)):
-                return CDFepoch.epochrange_epoch16(epochs, starttime, endtime)
+            if isinstance(epochs[0], (float, np.float64)):
+                return self.epochrange_epoch(epochs, starttime, endtime)
+            elif isinstance(epochs[0], (int, np.int64)):
+                return self.epochrange_tt2000(epochs, starttime, endtime)
+            elif isinstance(epochs[0], (complex, np.complex128)):
+                return self.epochrange_epoch16(epochs, starttime, endtime)
             else:
-                print('Bad input')
-                return None
+                raise TypeError('Bad input')
         else:
-            print('Bad input')
-            return None
+            raise TypeError('Bad input')
 
-    def encode_tt2000(tt2000, iso_8601=None):  # @NoSelf
+    def encode_tt2000(self, tt2000, iso_8601=None):
 
-        if (isinstance(tt2000, int) or isinstance(tt2000, np.int64)):
+        if isinstance(tt2000, (int, np.int64)):
             new_tt2000 = [tt2000]
-        elif (isinstance(tt2000, list) or isinstance(tt2000, np.ndarray)):
+        elif isinstance(tt2000, (list, np.ndarray)):
             new_tt2000 = tt2000
         else:
-            print('Bad input')
-            return None
+            raise TypeError('Bad input')
         count = len(new_tt2000)
         encodeds = []
-        for x in range(0, count):
+        for x in range(count):
             nanoSecSinceJ2000 = new_tt2000[x]
-            if (nanoSecSinceJ2000 == CDFepoch.FILLED_TT2000_VALUE):
-                if (iso_8601 == None or iso_8601 != False):
+            if nanoSecSinceJ2000 == self.FILLED_TT2000_VALUE:
+                if iso_8601 is None or iso_8601:
                     return '9999-12-31T23:59:59.999999999'
                 else:
                     return '31-Dec-9999 23:59:59.999.999.999'
-            if (nanoSecSinceJ2000 == CDFepoch.DEFAULT_TT2000_PADVALUE):
-                if (iso_8601 == None or iso_8601 != False):
+            if nanoSecSinceJ2000 == self.DEFAULT_TT2000_PADVALUE:
+                if iso_8601 is None or iso_8601:
                     return '0000-01-01T00:00:00.000000000'
                 else:
                     return '01-Jan-0000 00:00:00.000.000.000'
-            datetime = CDFepoch.breakdown_tt2000(nanoSecSinceJ2000)
+
+            datetime = self.breakdown_tt2000(nanoSecSinceJ2000)
             ly = datetime[0]
             lm = datetime[1]
             ld = datetime[2]
@@ -379,7 +354,8 @@ class CDFepoch:
             ll = datetime[6]
             lu = datetime[7]
             la = datetime[8]
-            if (iso_8601 == None or iso_8601 != False):
+
+            if iso_8601 is None or iso_8601:
                 # yyyy-mm-ddThh:mm:ss.mmmuuunnn
                 encoded = str(ly).zfill(4)
                 encoded += '-'
@@ -400,7 +376,7 @@ class CDFepoch:
                 # dd-mmm-yyyy hh:mm:ss.mmm.uuu.nnn
                 encoded = str(ld).zfill(2)
                 encoded += '-'
-                encoded += CDFepoch.month_Token[lm-1]
+                encoded += MONTH_TOKEN[lm - 1]
                 encoded += '-'
                 encoded += str(ly).zfill(4)
                 encoded += ' '
@@ -416,13 +392,13 @@ class CDFepoch:
                 encoded += '.'
                 encoded += str(la).zfill(3)
 
-            if (count == 1):
+            if count == 1:
                 return encoded
             else:
                 encodeds.append(encoded)
         return encodeds
 
-    def breakdown_tt2000(tt2000, to_np=None):  # @NoSelf
+    def breakdown_tt2000(self, tt2000, to_np: bool=False):
         """
         Breaks down the epoch(s) into UTC components.
 
@@ -440,47 +416,47 @@ class CDFepoch:
 
         Specify to_np to True, if the result should be in numpy array.
         """
-        if (isinstance(tt2000, int) or isinstance(tt2000, np.int64)):
+
+        if isinstance(tt2000, (int, np.int64)):
             new_tt2000 = [tt2000]
-        elif (isinstance(tt2000, list) or isinstance(tt2000, tuple) or
-              isinstance(tt2000, np.ndarray)):
+        elif isinstance(tt2000, (list, tuple, np.ndarray)):
             new_tt2000 = tt2000
         else:
-            print('Bad input data')
-            return None
+            raise TypeError('Bad input data')
+
         count = len(new_tt2000)
         toutcs = []
-        for x in range(0, count):
+        for x in range(count):
             nanoSecSinceJ2000 = new_tt2000[x]
-            toPlus = 0.0
+            # toPlus = 0.0
             t3 = nanoSecSinceJ2000
-            datx = CDFepoch._LeapSecondsfromJ2000(nanoSecSinceJ2000)
+            datx = self._LeapSecondsfromJ2000(nanoSecSinceJ2000)
             if (nanoSecSinceJ2000 > 0):
-                secSinceJ2000 = int(nanoSecSinceJ2000/CDFepoch.SECinNanoSecsD)
+                secSinceJ2000 = int(nanoSecSinceJ2000 / self.SECinNanoSecsD)
                 nansec = int(nanoSecSinceJ2000 - secSinceJ2000 *
-                             CDFepoch.SECinNanoSecs)
+                             self.SECinNanoSecs)
                 secSinceJ2000 = secSinceJ2000 - 32
                 secSinceJ2000 = secSinceJ2000 + 43200
                 nansec = nansec - 184000000
             else:
-                nanoSecSinceJ2000 = nanoSecSinceJ2000 + CDFepoch.T12hinNanoSecs
-                nanoSecSinceJ2000 = nanoSecSinceJ2000 - CDFepoch.dTinNanoSecs
-                secSinceJ2000 = int(nanoSecSinceJ2000/CDFepoch.SECinNanoSecsD)
+                nanoSecSinceJ2000 = nanoSecSinceJ2000 + self.T12hinNanoSecs
+                nanoSecSinceJ2000 = nanoSecSinceJ2000 - self.dTinNanoSecs
+                secSinceJ2000 = int(nanoSecSinceJ2000 / self.SECinNanoSecsD)
                 nansec = int(nanoSecSinceJ2000 - secSinceJ2000 *
-                             CDFepoch.SECinNanoSecs)
+                             self.SECinNanoSecs)
             if (nansec < 0):
-                nansec = CDFepoch.SECinNanoSecs + nansec
+                nansec = self.SECinNanoSecs + nansec
                 secSinceJ2000 = secSinceJ2000 - 1
-            t2 = secSinceJ2000 * CDFepoch.SECinNanoSecs + nansec
+            t2 = secSinceJ2000 * self.SECinNanoSecs + nansec
             if (datx[0] > 0.0):
                 # post-1972...
                 secSinceJ2000 = secSinceJ2000 - int(datx[0])
-                epoch = CDFepoch.J2000Since0AD12hSec + secSinceJ2000
+                epoch = self.J2000Since0AD12hSec + secSinceJ2000
                 if (datx[1] == 0.0):
-                    date1 = CDFepoch._EPOCHbreakdownTT2000(epoch)
+                    date1 = _EPOCHbreakdownTT2000(epoch)
                 else:
                     epoch = epoch - 1
-                    date1 = CDFepoch._EPOCHbreakdownTT2000(epoch)
+                    date1 = _EPOCHbreakdownTT2000(epoch)
                     date1[5] = date1[5] + 1
                 ye1 = date1[0]
                 mo1 = date1[1]
@@ -490,55 +466,55 @@ class CDFepoch:
                 se1 = date1[5]
             else:
                 # pre-1972...
-                epoch = secSinceJ2000 + CDFepoch.J2000Since0AD12hSec
-                xdate1 = CDFepoch._EPOCHbreakdownTT2000(epoch)
+                epoch = secSinceJ2000 + self.J2000Since0AD12hSec
+                xdate1 = _EPOCHbreakdownTT2000(epoch)
                 xdate1.append(0)
                 xdate1.append(0)
                 xdate1.append(nansec)
-                tmpNanosecs = CDFepoch.compute_tt2000(xdate1)
+                tmpNanosecs = self.compute_tt2000(xdate1)
                 if (tmpNanosecs != t3):
-                    dat0 = CDFepoch._LeapSecondsfromYMD(xdate1[0],
-                                                        xdate1[1], xdate1[2])
-                    tmpx = t2 - int(dat0 * CDFepoch.SECinNanoSecs)
-                    tmpy = int(float(tmpx/CDFepoch.SECinNanoSecsD))
-                    nansec = int(tmpx - tmpy * CDFepoch.SECinNanoSecs)
+                    dat0 = self._LeapSecondsfromYMD(xdate1[0],
+                                                    xdate1[1], xdate1[2])
+                    tmpx = t2 - int(dat0 * self.SECinNanoSecs)
+                    tmpy = int(float(tmpx / self.SECinNanoSecsD))
+                    nansec = int(tmpx - tmpy * self.SECinNanoSecs)
                 if (nansec < 0):
-                    nansec = CDFepoch.SECinNanoSecs + nansec
+                    nansec = self.SECinNanoSecs + nansec
                     tmpy = tmpy - 1
-                    epoch = tmpy + CDFepoch.J2000Since0AD12hSec
-                    xdate1 = CDFepoch._EPOCHbreakdownTT2000(epoch)
+                    epoch = tmpy + self.J2000Since0AD12hSec
+                    xdate1 = _EPOCHbreakdownTT2000(epoch)
                     xdate1.append(0)
                     xdate1.append(0)
                     xdate1.append(nansec)
-                    tmpNanosecs = CDFepoch.compute_tt2000(xdate1)
+                    tmpNanosecs = self.compute_tt2000(xdate1)
                 if (tmpNanosecs != t3):
-                    dat0 = CDFepoch._LeapSecondsfromYMD(xdate1[0],
-                                                        xdate1[1], xdate1[2])
-                    tmpx = t2 - int(dat0 * CDFepoch.SECinNanoSecs)
-                    tmpy = int((1.0*tmpx)/CDFepoch.SECinNanoSecsD)
-                    nansec = int(tmpx - tmpy * CDFepoch.SECinNanoSecs)
+                    dat0 = self._LeapSecondsfromYMD(xdate1[0],
+                                                    xdate1[1], xdate1[2])
+                    tmpx = t2 - int(dat0 * self.SECinNanoSecs)
+                    tmpy = int((1.0 * tmpx) / self.SECinNanoSecsD)
+                    nansec = int(tmpx - tmpy * self.SECinNanoSecs)
                     if (nansec < 0):
-                        nansec = CDFepoch.SECinNanoSecs + nansec
+                        nansec = self.SECinNanoSecs + nansec
                         tmpy = tmpy - 1
-                    epoch = tmpy + CDFepoch.J2000Since0AD12hSec
-                    xdate1 = CDFepoch._EPOCHbreakdownTT2000(epoch)
+                    epoch = tmpy + self.J2000Since0AD12hSec
+                    xdate1 = _EPOCHbreakdownTT2000(epoch)
                     xdate1.append(0)
                     xdate1.append(0)
                     xdate1.append(nansec)
-                    tmpNanosecs = CDFepoch.compute_tt2000(xdate1)
+                    tmpNanosecs = self.compute_tt2000(xdate1)
                     if (tmpNanosecs != t3):
-                        dat0 = CDFepoch._LeapSecondsfromYMD(xdate1[0],
-                                                            xdate1[1],
-                                                            xdate1[2])
-                        tmpx = t2 - int(dat0 * CDFepoch.SECinNanoSecs)
-                        tmpy = int((1.0*tmpx)/CDFepoch.SECinNanoSecsD)
-                        nansec = int(tmpx - tmpy * CDFepoch.SECinNanoSecs)
+                        dat0 = self._LeapSecondsfromYMD(xdate1[0],
+                                                        xdate1[1],
+                                                        xdate1[2])
+                        tmpx = t2 - int(dat0 * self.SECinNanoSecs)
+                        tmpy = int((1.0 * tmpx) / self.SECinNanoSecsD)
+                        nansec = int(tmpx - tmpy * self.SECinNanoSecs)
                         if (nansec < 0):
-                            nansec = CDFepoch.SECinNanoSecs + nansec
+                            nansec = self.SECinNanoSecs + nansec
                             tmpy = tmpy - 1
-                        epoch = tmpy + CDFepoch.J2000Since0AD12hSec
+                        epoch = tmpy + self.J2000Since0AD12hSec
                         # One more determination
-                        xdate1 = CDFepoch._EPOCHbreakdownTT2000(epoch)
+                        xdate1 = _EPOCHbreakdownTT2000(epoch)
                 ye1 = int(xdate1[0])
                 mo1 = int(xdate1[1])
                 da1 = int(xdate1[2])
@@ -563,30 +539,423 @@ class CDFepoch:
             datetime.append(ma1)
             datetime.append(na1)
             if (count == 1):
-                if (to_np == None):
+                if not to_np:
                     return datetime
                 else:
                     return np.array(datetime)
             else:
                 toutcs.append(datetime)
-        if (to_np == None):
+
+        if not to_np:
             return toutcs
         else:
             return np.array(toutcs)
 
-    def compute_tt2000(datetimes, to_np=None):  # @NoSelf
+    def _LeapSecondsfromYMD(self, year, month, day):
 
-        if (not isinstance(datetimes, list) and not isinstance(datetimes, tuple)):
-            print('datetime must be in list form')
-            return None
-        if (isinstance(datetimes[0], numbers.Number)):
-            new_datetimes = [datetimes]
-            count = 1
+        j = -1
+        m = 12 * year + month
+        for i, _ in reversed(list(enumerate(self.LTS))):
+            n = 12 * self.LTS[i][0] + self.LTS[i][1]
+            if (m >= n):
+                j = i
+                break
+        if (j == -1):
+            return 0.0
+        da = self.LTS[j][3]
+        # pre-1972
+        if (j < self.NERA1):
+            jda = _JulianDay(year, month, day)
+            da = da + ((jda - self.MJDbase) - self.LTS[j][4]) * self.LTS[j][5]
+        return da
+
+    def _LeapSecondsfromJ2000(self, nanosecs):
+
+        da = []
+        da.append(0.0)
+        da.append(0.0)
+        j = -1
+        if self.NST is None:
+            self._LoadLeapNanoSecondsTable()
+        for i, _ in reversed(list(enumerate(self.NST))):
+            if (nanosecs >= self.NST[i]):
+                j = i
+                if i < (self.NDAT - 1):
+                    if (nanosecs + 1000000000) >= self.NST[i + 1]:
+                        da[1] = 1.0
+                break
+        if (j <= self.NERA1):
+            return da
+        da[0] = self.LTS[j][3]
+        return da
+
+    def _LoadLeapNanoSecondsTable(self):
+
+        self.NST = []
+        for ix in range(self.NERA1):
+            self.NST.append(self.FILLED_TT2000_VALUE)
+        for ix in range(self.NERA1, self.NDAT):
+            self.NST.append(self.compute_tt2000([int(self.LTS[ix][0]),
+                                                 int(self.LTS[ix][1]),
+                                                 int(self.LTS[ix][2]),
+                                                 0, 0, 0, 0, 0, 0]))
+
+    def epochrange_tt2000(self, epochs, starttime=None, endtime=None):
+
+        if isinstance(epochs, (int, np.int64)):
+            # new2_epochs = [epochs]
+            pass
+        elif isinstance(epochs, (list, tuple, np.ndarray)):
+            if isinstance(epochs[0], (int, np.int64)):
+                # new2_epochs = epochs
+                pass
+            else:
+                raise TypeError('Bad data')
         else:
-            count = len(datetimes)
-            new_datetimes = datetimes
+            raise TypeError('Bad data')
+        if starttime is None:
+            stime = int(-9223372036854775807)
+        else:
+            if isinstance(starttime, (int, np.int64)):
+                stime = starttime
+            elif (isinstance(starttime, list)):
+                stime = self.compute_tt2000(starttime)
+            else:
+                raise TypeError('Bad start time')
+
+        if endtime is not None:
+            if isinstance(endtime, (int, np.int64)):
+                etime = endtime
+            elif isinstance(endtime, (list, tuple)):
+                etime = self.compute_tt2000(endtime)
+            else:
+                raise TypeError('Bad end time')
+        else:
+            etime = int(9223372036854775807)
+
+        if stime > etime:
+            raise ValueError('Invalid start/end time')
+
+        if isinstance(epochs, (list, tuple)):
+            new_epochs = np.array(epochs)
+        else:
+            new_epochs = epochs
+
+        return np.where(np.logical_and(new_epochs >= stime, new_epochs <= etime))[0]
+
+    def epochrange_epoch16(self, epochs: Sequence[complex],
+                           starttime: Sequence[complex]=None, endtime: Sequence[complex]=None) -> np.ndarray:
+
+        if isinstance(epochs, (complex, np.complex128)):
+            new_epochs = [epochs]
+        elif isinstance(epochs, (list, tuple, np.ndarray)):
+            if isinstance(epochs[0], (complex, np.complex128)):
+                new_epochs = epochs
+            else:
+                raise TypeError('Bad data')
+        else:
+            raise TypeError('Bad data')
+
+        if starttime is None:
+            stime = []
+            stime.append(-1.0E31)
+            stime.append(-1.0E31)
+        else:
+            if isinstance(starttime, (complex, np.complex128)):
+                stime = []
+                stime.append(starttime.real)
+                stime.append(starttime.imag)
+            elif isinstance(starttime, (list, tuple)):
+                sstime = compute_epoch16(starttime)
+                stime = []
+                stime.append(sstime.real)
+                stime.append(sstime.imag)
+            else:
+                raise TypeError('Bad start time')
+
+        if endtime is not None:
+            if isinstance(endtime, (complex, np.complex128)):
+                etime = []
+                etime.append(endtime.real)
+                etime.append(endtime.imag)
+            elif isinstance(endtime, (list, tuple)):
+                eetime = compute_epoch16(endtime)
+                etime = []
+                etime.append(eetime.real)
+                etime.append(eetime.imag)
+            else:
+                raise TypeError('Bad start time')
+
+        else:
+            etime = []
+            etime.append(1.0E31)
+            etime.append(1.0E31)
+        if (stime[0] > etime[0] or (stime[0] == etime[0] and stime[1] > etime[1])):
+            raise ValueError('Invalid start/end time')
+
+        count = len(new_epochs)
+        epoch16 = []
+        for x in range(count):
+            epoch16.append(new_epochs[x].real)
+            epoch16.append(new_epochs[x].imag)
+        count = count * 2
+        indx = []
+        if (epoch16[0] > etime[0] or (epoch16[0] == etime[0] and
+                                      epoch16[1] > etime[1])):
+            return None
+        if (epoch16[count - 2] < stime[0] or
+            (epoch16[count - 2] == stime[0] and
+             epoch16[count - 1] < stime[1])):
+            return None
+
+        for x in range(0, count, 2):
+            if (epoch16[x] < stime[0]):
+                continue
+            elif (epoch16[x] == stime[0]):
+                if (epoch16[x + 1] < stime[1]):
+                    continue
+                else:
+                    indx.append(int(x / 2))
+                    break
+            else:
+                indx.append(int(x / 2))
+                break
+        if (len(indx) == 0):
+            indx.append(0)
+        hasadded = False
+        for x in range(0, count, 2):
+            if (epoch16[x] < etime[0]):
+                continue
+            elif (epoch16[x] == etime[0]):
+                if (epoch16[x + 1] > etime[1]):
+                    indx.append(int((x - 1) / 2))
+                    hasadded = True
+                    break
+            else:
+                indx.append(int((x - 1) / 2))
+                hasadded = True
+                break
+
+        if not hasadded:
+            indx.append(int(count / 2) - 1)
+
+        return np.arange(indx[0], indx[1] + 1, step=1)
+
+    def epochrange_epoch(self, epochs, starttime=None, endtime=None):
+
+        if isinstance(epochs, (float, np.float64)):
+            # new2_epochs = [epochs]
+            pass
+        elif isinstance(epochs, (list, tuple, np.ndarray)):
+            if isinstance(epochs[0], (float, np.float64)):
+                # new2_epochs = epochs
+                pass
+            else:
+                raise ValueError('Bad data')
+        else:
+            raise ValueError('Bad data')
+
+        if starttime is None:
+            stime = 0.0
+        else:
+            if isinstance(starttime, (float, int, np.float64)):
+                stime = starttime
+            elif isinstance(starttime, (list, tuple)):
+                stime = compute_epoch(starttime)
+            else:
+                raise ValueError('Bad start time')
+        if endtime is not None:
+            if isinstance(endtime, (float, int, np.float64)):
+                etime = endtime
+            elif isinstance(endtime, (list, tuple)):
+                etime = compute_epoch(endtime)
+            else:
+                raise ValueError('Bad end time')
+        else:
+            etime = 1.0E31
+        if (stime > etime):
+            raise ValueError('Invalid start/end time')
+        if isinstance(epochs, (list, tuple)):
+            new_epochs = np.array(epochs)
+        else:
+            new_epochs = epochs
+        return np.where(np.logical_and(new_epochs >= stime, new_epochs <= etime))[0]
+
+    def parse(self, value, to_np: bool=False):
+        """
+        Parses the provided date/time string(s) into CDF epoch value(s).
+
+        For CDF_EPOCH:
+                The string has to be in the form of 'dd-mmm-yyyy hh:mm:ss.xxx' or
+                'yyyy-mm-ddThh:mm:ss.xxx' (in iso_8601). The string is the output
+                from encode function.
+
+        For CDF_EPOCH16:
+                The string has to be in the form of
+                'dd-mmm-yyyy hh:mm:ss.mmm.uuu.nnn.ppp' or
+                'yyyy-mm-ddThh:mm:ss.mmmuuunnnppp' (in iso_8601). The string is
+                the output from encode function.
+
+        For TT2000:
+                The string has to be in the form of
+                'dd-mmm-yyyy hh:mm:ss.mmm.uuu.nnn' or
+                'yyyy-mm-ddThh:mm:ss.mmmuuunnn' (in iso_8601). The string is
+                the output from encode function.
+
+        Specify to_np to True, if the result should be in numpy class.
+        """
+        if isinstance(value, (list, tuple)) and not isinstance(value[0], str):
+            raise TypeError('should be a string or a list of string')
+        elif not isinstance(value, (list, tuple, str)):
+            raise TypeError('should be a string or a list of string')
+        else:
+            if isinstance(value, (list, tuple)):
+                num = len(value)
+                epochs = []
+                for x in range(num):
+                    epochs.append(self._parse_epoch(value[x]))
+                if not to_np:
+                    return epochs
+                else:
+                    return np.array(epochs)
+            else:
+                if not to_np:
+                    return self._parse_epoch(value)
+                else:
+                    return np.array(self._parse_epoch(value))
+
+    def _parse_epoch(self, value):
+        if isinstance(value, (list, tuple)):
+            epochs = []
+            for x in range(len(value)):
+                epochs.append(value[x])
+            return epochs
+        else:
+            if len(value) in (23, 24):
+                # CDF_EPOCH
+                if value.lower() in ('31-dec-9999 23:59:59.999', '9999-12-31t23:59:59.999'):
+                    return -1.0E31
+                else:
+                    if len(value) == 24:
+                        date = re.findall('(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)', value)
+                        dd = int(date[0][0])
+                        mm = self._month_index(date[0][1])
+                        yy = int(date[0][2])
+                        hh = int(date[0][3])
+                        mn = int(date[0][4])
+                        ss = int(date[0][5])
+                        ms = int(date[0][6])
+                    else:
+                        date = re.findall('(\d+)\-(\d+)\-(\d+)T(\d+)\:(\d+)\:(\d+)\.(\d+)',
+                                          value)
+                        yy = int(date[0][0])
+                        mm = int(date[0][1])
+                        dd = int(date[0][2])
+                        hh = int(date[0][3])
+                        mn = int(date[0][4])
+                        ss = int(date[0][5])
+                        ms = int(date[0][6])
+
+                    return compute_epoch([yy, mm, dd, hh, mn, ss, ms])
+
+            elif len(value) == 36 or (len(value) == 32 and value[10].lower() == 't'):
+                # CDF_EPOCH16
+                if value.lower() in ('31-dec-9999 23:59:59.999.999.999.999', '9999-12-31t23:59:59.999999999999'):
+                    return -1.0E31 - 1.0E31j
+                else:
+                    if len(value) == 36:
+                        date = re.findall('(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)\.(\d+)\.(\d+)\.(\d+)',
+                                          value)
+                        dd = int(date[0][0])
+                        mm = self._month_index(date[0][1])
+                        yy = int(date[0][2])
+                        hh = int(date[0][3])
+                        mn = int(date[0][4])
+                        ss = int(date[0][5])
+                        ms = int(date[0][6])
+                        us = int(date[0][7])
+                        ns = int(date[0][8])
+                        ps = int(date[0][9])
+                    else:
+                        date = re.findall('(\d+)\-(\d+)\-(\d+)T(\d+)\:(\d+)\:(\d+)\.(\d+)',
+                                          value)
+                        yy = int(date[0][0])
+                        mm = int(date[0][1])
+                        dd = int(date[0][2])
+                        hh = int(date[0][3])
+                        mn = int(date[0][4])
+                        ss = int(date[0][5])
+                        subs = int(date[0][6])
+                        ms = int(subs / 1000000000)
+                        subms = int(subs % 1000000000)
+                        us = int(subms / 1000000)
+                        subus = int(subms % 1000000)
+                        ns = int(subus / 1000)
+                        ps = int(subus % 1000)
+                    return compute_epoch16([yy, mm, dd, hh, mn, ss, ms, us, ns, ps])
+
+            elif len(value) == 29 or (len(value) == 32 and value[11] == ' '):
+                # CDF_TIME_TT2000
+                value = value.lower()
+                if value in ('9999-12-31t23:59:59.999999999', '31-dec-9999 23:59:59.999.999.999'):
+                    return -9223372036854775808
+                elif value in ('0000-01-01t00:00.000000000', '01-jan-0000 00:00.000.000.000'):
+                    return -9223372036854775807
+                else:
+                    if len(value) == 29:
+                        date = re.findall('(\d+)\-(\d+)\-(\d+)t(\d+)\:(\d+)\:(\d+)\.(\d+)',
+                                          value)
+                        yy = int(date[0][0])
+                        mm = int(date[0][1])
+                        dd = int(date[0][2])
+                        hh = int(date[0][3])
+                        mn = int(date[0][4])
+                        ss = int(date[0][5])
+                        subs = int(date[0][6])
+                        ms = int(subs / 1000000)
+                        subms = int(subs % 1000000)
+                        us = int(subms / 1000)
+                        ns = int(subms % 1000)
+                    else:
+                        date = re.findall('(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)\.(\d+)\.(\d+)',
+                                          value)
+                        dd = int(date[0][0])
+                        mm = self._month_index(date[0][1])
+                        yy = int(date[0][2])
+                        hh = int(date[0][3])
+                        mn = int(date[0][4])
+                        ss = int(date[0][5])
+                        ms = int(date[0][6])
+                        us = int(date[0][7])
+                        ns = int(date[0][8])
+                    return self.compute_tt2000([yy, mm, dd, hh, mn, ss, ms, us, ns])
+            else:
+                raise TypeError('Invalid cdf epoch type')
+
+    def getVersion(self):
+        """
+        Shows the code version.
+        """
+        print('epochs version: {}.{}.{}'.format(self.version, self.release, self.increment))
+        print('Date: 2018/01/11')
+
+    def getLeapSecondLastUpdated(self):
+        """
+        Shows the latest date a leap second was added to the leap second table.
+        """
+        print('Leap second last updated: {}-{}-{}'.format(self.LTS[-1][0], self.LTS[-1][1], self.LTS[-1][2]))
+
+    def compute_tt2000(self, datetimes, to_np: bool=False):
+
+        if not isinstance(datetimes, (list, tuple)):
+            raise TypeError('datetime must be in list form')
+
+        new_datetimes = [datetimes] if isinstance(datetimes[0], numbers.Number) else datetimes
+
+        count = len(new_datetimes)
+
         nanoSecSinceJ2000s = []
-        for x in range(0, count):
+        for x in range(count):
             datetime = new_datetimes[x]
             year = int(datetime[0])
             month = int(datetime[1])
@@ -670,1142 +1039,714 @@ class CDFepoch:
                 usec = int(xxx)
                 nsec = int(1000.0 * (xxx - usec))
             else:
-                print('Invalid tt2000 components')
-                return None
-            if (month == 0):
+                raise ValueError('Invalid tt2000 components')
+
+            if month == 0:
                 month = 1
+
             if (year == 9999 and month == 12 and day == 31 and hour == 23 and
                 minute == 59 and second == 59 and msec == 999 and
                     usec == 999 and nsec == 999):
-                nanoSecSinceJ2000 = CDFepoch.FILLED_TT2000_VALUE
+                nanoSecSinceJ2000 = FILLED_TT2000_VALUE
             elif (year == 0 and month == 1 and day == 1 and hour == 0 and
                   minute == 0 and second == 0 and msec == 0 and usec == 0 and
                   nsec == 0):
-                nanoSecSinceJ2000 = CDFepoch.DEFAULT_TT2000_PADVALUE
+                nanoSecSinceJ2000 = DEFAULT_TT2000_PADVALUE
             else:
                 iy = 10000000 * month + 10000 * day + year
-                if (iy != CDFepoch.currentDay):
-                    CDFepoch.currentDay = iy
-                    CDFepoch.currentLeapSeconds = CDFepoch._LeapSecondsfromYMD(year, month, day)
-                    CDFepoch.currentJDay = CDFepoch._JulianDay(year, month, day)
-                jd = CDFepoch.currentJDay
-                jd = jd - CDFepoch.JulianDateJ2000_12h
-                subDayinNanoSecs = int(hour*CDFepoch.HOURinNanoSecs +
-                                       minute*CDFepoch.MINUTEinNanoSecs +
-                                       second*CDFepoch.SECinNanoSecs+msec*1000000 +
-                                       usec*1000+nsec)
-                nanoSecSinceJ2000 = int(jd * CDFepoch.DAYinNanoSecs +
+                if (iy != self.currentDay):
+                    self.currentDay = iy
+                    self.currentLeapSeconds = self._LeapSecondsfromYMD(year, month, day)
+                    self.currentJDay = _JulianDay(year, month, day)
+                jd = self.currentJDay
+                jd = jd - self.JulianDateJ2000_12h
+                subDayinNanoSecs = int(hour * self.HOURinNanoSecs +
+                                       minute * self.MINUTEinNanoSecs +
+                                       second * self.SECinNanoSecs + msec * 1000000 +
+                                       usec * 1000 + nsec)
+                nanoSecSinceJ2000 = int(jd * self.DAYinNanoSecs +
                                         subDayinNanoSecs)
-                t2 = int(CDFepoch.currentLeapSeconds * CDFepoch.SECinNanoSecs)
+                t2 = int(self.currentLeapSeconds * self.SECinNanoSecs)
                 if (nanoSecSinceJ2000 < 0):
                     nanoSecSinceJ2000 = int(nanoSecSinceJ2000 + t2)
                     nanoSecSinceJ2000 = int(nanoSecSinceJ2000 +
-                                            CDFepoch.dTinNanoSecs)
+                                            self.dTinNanoSecs)
                     nanoSecSinceJ2000 = int(nanoSecSinceJ2000 -
-                                            CDFepoch.T12hinNanoSecs)
+                                            self.T12hinNanoSecs)
                 else:
                     nanoSecSinceJ2000 = int(nanoSecSinceJ2000 -
-                                            CDFepoch.T12hinNanoSecs)
+                                            self.T12hinNanoSecs)
                     nanoSecSinceJ2000 = int(nanoSecSinceJ2000 + t2)
                     nanoSecSinceJ2000 = int(nanoSecSinceJ2000 +
-                                            CDFepoch.dTinNanoSecs)
-            if (count == 1):
-                if (to_np == None):
+                                            self.dTinNanoSecs)
+            if count == 1:
+                if not to_np:
                     return int(nanoSecSinceJ2000)
                 else:
                     return np.array(int(nanoSecSinceJ2000))
             else:
                 nanoSecSinceJ2000s.append(int(nanoSecSinceJ2000))
-        if (to_np == None):
+
+        if not to_np:
             return nanoSecSinceJ2000s
         else:
             return np.array(nanoSecSinceJ2000s)
 
-    def _LeapSecondsfromYMD(year, month, day):  # @NoSelf
 
-        j = -1
-        m = 12 * year + month
-        for i, _ in reversed(list(enumerate(CDFepoch.LTS))):
-            n = 12 * CDFepoch.LTS[i][0] + CDFepoch.LTS[i][1]
-            if (m >= n):
-                j = i
-                break
-        if (j == -1):
-            return 0.0
-        da = CDFepoch.LTS[j][3]
-        # pre-1972
-        if (j < CDFepoch.NERA1):
-            jda = CDFepoch._JulianDay(year, month, day)
-            da = da + ((jda - CDFepoch.MJDbase) - CDFepoch.LTS[j][4]) * CDFepoch.LTS[j][5]
-        return da
+def _EPOCHbreakdownTT2000(epoch: float) -> List[int]:
 
-    def _LeapSecondsfromJ2000(nanosecs):  # @NoSelf
+    second_AD = epoch
+    minute_AD = second_AD / 60.0
+    hour_AD = minute_AD / 60.0
+    day_AD = hour_AD / 24.0
 
-        da = []
-        da.append(0.0)
-        da.append(0.0)
-        j = -1
-        if (CDFepoch.NST == None):
-            CDFepoch._LoadLeapNanoSecondsTable()
-        for i, _ in reversed(list(enumerate(CDFepoch.NST))):
-            if (nanosecs >= CDFepoch.NST[i]):
-                j = i
-                if (i < (CDFepoch.NDAT - 1)):
-                    if ((nanosecs + 1000000000) >= CDFepoch.NST[i+1]):
-                        da[1] = 1.0
-                break
-        if (j <= CDFepoch.NERA1):
-            return da
-        da[0] = CDFepoch.LTS[j][3]
-        return da
+    jd = int(1721060 + day_AD)
+    L = jd + 68569
+    n = int(4 * L / 146097)
+    L = L - int((146097 * n + 3) / 4)
+    i = int(4000 * (L + 1) / 1461001)
+    L = L - int(1461 * i / 4) + 31
+    j = int(80 * L / 2447)
+    k = L - int(2447 * j / 80)
+    L = int(j / 11)
+    j = j + 2 - 12 * L
+    i = 100 * (n - 49) + i + L
 
-    def _LoadLeapNanoSecondsTable():  # @NoSelf
+    date = []
+    date.append(i)
+    date.append(j)
+    date.append(k)
+    date.append(int(hour_AD % 24.0))
+    date.append(int(minute_AD % 60.0))
+    date.append(int(second_AD % 60.0))
 
-        CDFepoch.NST = []
-        for ix in range(0, CDFepoch.NERA1):
-            CDFepoch.NST.append(CDFepoch.FILLED_TT2000_VALUE)
-        for ix in range(CDFepoch.NERA1, CDFepoch.NDAT):
-            CDFepoch.NST.append(CDFepoch.compute_tt2000([int(CDFepoch.LTS[ix][0]),
-                                                         int(CDFepoch.LTS[ix][1]),
-                                                         int(CDFepoch.LTS[ix][2]),
-                                                         0, 0, 0, 0, 0, 0]))
+    return date
 
-    def _EPOCHbreakdownTT2000(epoch):  # @NoSelf
 
-        second_AD = epoch
-        minute_AD = second_AD / 60.0
-        hour_AD = minute_AD / 60.0
-        day_AD = hour_AD / 24.0
+def encode_epoch16(epochs: Sequence[complex], iso_8601: bool=True):
 
-        jd = int(1721060 + day_AD)
-        l = jd+68569
-        n = int(4*l/146097)
-        l = l-int((146097*n+3)/4)
-        i = int(4000*(l+1)/1461001)
-        l = l-int(1461*i/4)+31
-        j = int(80*l/2447)
-        k = l-int(2447*j/80)
-        l = int(j/11)
-        j = j+2-12*l
-        i = 100*(n-49)+i+l
+    if isinstance(epochs, (complex, np.complex128)):
+        new_epochs = [epochs]
+    elif isinstance(epochs, (list, tuple, np.ndarray)):
+        new_epochs = epochs
+    else:
+        raise ValueError('Bad data')
 
-        date = []
-        date.append(i)
-        date.append(j)
-        date.append(k)
-        date.append(int(hour_AD % 24.0))
-        date.append(int(minute_AD % 60.0))
-        date.append(int(second_AD % 60.0))
-        return date
-
-    def epochrange_tt2000(epochs, starttime=None, endtime=None):  # @NoSelf
-
-        if (isinstance(epochs, int) or isinstance(epochs, np.int64)):
-            new2_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
-            if (isinstance(epochs[0], int) or
-                    isinstance(epochs[0], np.int64)):
-                new2_epochs = epochs
-            else:
-                print('Bad data')
-                return None
+    count = len(new_epochs)
+    encodeds = []
+    for x in range(count):
+        # complex
+        if (new_epochs[x].real == -1.0E31) and (new_epochs[x].imag == -1.0E31):
+            encoded = '9999-12-31T23:59:59.999999999999' if iso_8601 else '31-Dec-9999 23:59:59.999.999.999.999'
         else:
-            print('Bad data')
-            return None
-        if (starttime == None):
-            stime = int(-9223372036854775807)
+            encoded = _encodex_epoch16(new_epochs[x], iso_8601)
+        if (count == 1):
+            return encoded
         else:
-            if (isinstance(starttime, int) or isinstance(starttime, np.int64)):
-                stime = starttime
-            elif (isinstance(starttime, list)):
-                stime = CDFepoch.compute_tt2000(starttime)
-            else:
-                print('Bad start time')
-                return None
-        if (endtime != None):
-            if (isinstance(endtime, int) or isinstance(endtime, np.int64)):
-                etime = endtime
-            elif (isinstance(endtime, list) or isinstance(endtime, tuple)):
-                etime = CDFepoch.compute_tt2000(endtime)
-            else:
-                print('Bad end time')
-                return None
-        else:
-            etime = int(9223372036854775807)
-        if (stime > etime):
-            print('Invalid start/end time')
-            return None
-        if (isinstance(epochs, list) or isinstance(epochs, tuple)):
-            new_epochs = np.array(epochs)
-        else:
-            new_epochs = epochs
-        return np.where(np.logical_and(new_epochs >= stime, new_epochs <= etime))[0]
-
-    def encode_epoch16(epochs, iso_8601=True):  # @NoSelf
-
-        if (isinstance(epochs, complex) or
-                isinstance(epochs, np.complex128)):
-            new_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
-            new_epochs = epochs
-        else:
-            print('Bad data')
-            return None
-        count = len(new_epochs)
-        encodeds = []
-        for x in range(0, count):
-            # complex
-            if ((new_epochs[x].real == -1.0E31) and (new_epochs[x].imag == -1.0E31)):
-                if iso_8601:
-                    encoded = '9999-12-31T23:59:59.999999999999'
-                else:
-                    encoded = '31-Dec-9999 23:59:59.999.999.999.999'
-            else:
-                encoded = CDFepoch._encodex_epoch16(new_epochs[x], iso_8601)
-            if (count == 1):
-                return encoded
-            else:
-                encodeds.append(encoded)
-        return encodeds
-
-    def _encodex_epoch16(epoch16, iso_8601=True):  # @NoSelf
-
-        components = CDFepoch.breakdown_epoch16(epoch16)
-        if iso_8601:
-            # year-mm-ddThh:mm:ss.mmmuuunnnppp
-            encoded = str(components[0]).zfill(4)
-            encoded += '-'
-            encoded += str(components[1]).zfill(2)
-            encoded += '-'
-            encoded += str(components[2]).zfill(2)
-            encoded += 'T'
-            encoded += str(components[3]).zfill(2)
-            encoded += ':'
-            encoded += str(components[4]).zfill(2)
-            encoded += ':'
-            encoded += str(components[5]).zfill(2)
-            encoded += '.'
-            encoded += str(components[6]).zfill(3)
-            encoded += str(components[7]).zfill(3)
-            encoded += str(components[8]).zfill(3)
-            encoded += str(components[9]).zfill(3)
-        else:
-            # dd-mmm-year hh:mm:ss.mmm.uuu.nnn.ppp
-            encoded = str(components[2]).zfill(2)
-            encoded += '-'
-            encoded += CDFepoch.month_Token[components[1]-1]
-            encoded += '-'
-            encoded += str(components[0]).zfill(4)
-            encoded += ' '
-            encoded += str(components[3]).zfill(2)
-            encoded += ':'
-            encoded += str(components[4]).zfill(2)
-            encoded += ':'
-            encoded += str(components[5]).zfill(2)
-            encoded += '.'
-            encoded += str(components[6]).zfill(3)
-            encoded += '.'
-            encoded += str(components[7]).zfill(3)
-            encoded += '.'
-            encoded += str(components[8]).zfill(3)
-            encoded += '.'
-            encoded += str(components[9]).zfill(3)
-        return encoded
-
-    def _JulianDay(y, m, d):  # @NoSelf
-
-        a1 = int(7*(int(y+int((m+9)/12)))/4)
-        a2 = int(3*(int(int(y+int((m-9)/7))/100)+1)/4)
-        a3 = int(275*m/9)
-        return (367*y - a1 - a2 + a3 + d + 1721029)
-
-    def compute_epoch16(datetimes, to_np=None):  # @NoSelf
-
-        if (not isinstance(datetimes, list) and
-                not isinstance(datetimes, tuple)):
-            print('Bad input')
-            return None
-        if (not isinstance(datetimes[0], list) and
-                not isinstance(datetimes[0], tuple)):
-            new_dates = []
-            new_dates = [datetimes]
-        else:
-            new_dates = datetimes
-        count = len(new_dates)
-        if (count == 0):
-            return None
-        epochs = []
-        for x in range(0, count):
-            epoch = []
-            date = new_dates[x]
-            items = len(date)
-            year = date[0]
-            month = date[1]
-            if (items > 9):
-                # y m d h m s ms us ns ps
-                day = int(date[2])
-                hour = int(date[3])
-                minute = int(date[4])
-                second = int(date[5])
-                msec = int(date[6])
-                usec = int(date[7])
-                nsec = int(date[8])
-                psec = int(date[9])
-            elif (items > 8):
-                # y m d h m s ms us ns
-                day = int(date[2])
-                hour = int(date[3])
-                minute = int(date[4])
-                second = int(date[5])
-                msec = int(date[6])
-                usec = int(date[7])
-                nsec = int(date[8])
-                psec = int(1000.0 * (date[8] - nsec))
-            elif (items > 7):
-                # y m d h m s ms us
-                day = int(date[2])
-                hour = int(date[3])
-                minute = int(date[4])
-                second = int(date[5])
-                msec = int(date[6])
-                usec = int(date[7])
-                xxx = int(1000.0 * (date[7] - usec))
-                nsec = int(xxx)
-                psec = int(1000.0 * (xxx - nsec))
-            elif (items > 6):
-                # y m d h m s ms
-                day = int(date[2])
-                hour = int(date[3])
-                minute = int(date[4])
-                second = int(date[5])
-                msec = int(date[6])
-                xxx = float(1000.0 * (date[6] - msec))
-                usec = int(xxx)
-                xxx = int(1000.0 * (xxx - usec))
-                nsec = int(xxx)
-                psec = int(1000.0 * (xxx - nsec))
-            elif (items > 5):
-                # y m d h m s
-                day = int(date[2])
-                hour = int(date[3])
-                minute = int(date[4])
-                second = int(date[5])
-                xxx = float(1000.0 * (date[5] - second))
-                msec = int(xxx)
-                xxx = float(1000.0 * (xxx - msec))
-                usec = int(xxx)
-                xxx = int(1000.0 * (xxx - usec))
-                nsec = int(xxx)
-                psec = int(1000.0 * (xxx - nsec))
-            elif (items > 4):
-                # y m d h m
-                day = int(date[2])
-                hour = int(date[3])
-                minute = int(date[4])
-                xxx = float(60.0 * (date[4] - minute))
-                second = int(xxx)
-                xxx = float(1000.0 * (xxx - second))
-                msec = int(xxx)
-                xxx = float(1000.0 * (xxx - msec))
-                usec = int(xxx)
-                xxx = int(1000.0 * (xxx - usec))
-                nsec = int(xxx)
-                psec = int(1000.0 * (xxx - nsec))
-            elif (items > 3):
-                # y m d h
-                day = int(date[2])
-                hour = int(date[3])
-                xxx = float(60.0 * (date[3] - hour))
-                minute = int(xxx)
-                xxx = float(60.0 * (xxx - minute))
-                second = int(xxx)
-                xxx = float(1000.0 * (xxx - second))
-                msec = int(xxx)
-                xxx = float(1000.0 * (xxx - msec))
-                usec = int(xxx)
-                xxx = int(1000.0 * (xxx - usec))
-                nsec = int(xxx)
-                psec = int(1000.0 * (xxx - nsec))
-            elif (items > 2):
-                # y m d
-                day = int(date[2])
-                xxx = float(24.0 * (date[2] - day))
-                hour = int(xxx)
-                xxx = float(60.0 * (xxx - hour))
-                minute = int(xxx)
-                xxx = float(60.0 * (xxx - minute))
-                second = int(xxx)
-                xxx = float(1000.0 * (xxx - second))
-                msec = int(xxx)
-                xxx = float(1000.0 * (xxx - msec))
-                usec = int(xxx)
-                xxx = int(1000.0 * (xxx - usec))
-                nsec = int(xxx)
-                psec = int(1000.0 * (xxx - nsec))
-            else:
-                print('Invalid epoch16 components')
-                return None
-            if (year < 0):
-                print('Illegal epoch field')
-                return
-            if (year == 9999 and month == 12 and day == 31 and hour == 23 and
-                minute == 59 and second == 59 and msec == 999 and
-                    usec == 999 and nsec == 999 and psec == 999):
-                epoch.append(-1.0E31)
-                epoch.append(-1.0E31)
-            elif ((year > 9999) or (month < 0 or month > 12) or
-                  (hour < 0 or hour > 23) or (minute < 0 or minute > 59) or
-                  (second < 0 or second > 59) or (msec < 0 or msec > 999) or
-                  (usec < 0 or usec > 999) or (nsec < 0 or nsec > 999) or
-                  (psec < 0 or psec > 999)):
-                epoch = CDFepoch._computeEpoch16(year, month, day, hour,
-                                                 minute, second, msec,
-                                                 usec, nsec, psec)
-            else:
-                if (month == 0):
-                    if (day < 1 or day > 366):
-                        epoch = CDFepoch._computeEpoch16(year, month, day, hour,
-                                                         minute, second, msec,
-                                                         usec, nsec, psec)
-                else:
-                    if (day < 1 or day > 31):
-                        epoch = CDFepoch._computeEpoch16(year, month, day, hour,
-                                                         minute, second, msec,
-                                                         usec, nsec, psec)
-                if (month == 0):
-                    daysSince0AD = CDFepoch._JulianDay(year, 1, 1) + (day-1) - 1721060
-                else:
-                    daysSince0AD = CDFepoch._JulianDay(year, month, day) - 1721060
-                secInDay = (3600 * hour) + (60 * minute) + second
-                epoch16_0 = float(86400.0 * daysSince0AD) + float(secInDay)
-                epoch16_1 = float(psec) + float(1000.0 * nsec) + float(1000000.0 * usec) + float(1000000000.0 * msec)
-                epoch.append(epoch16_0)
-                epoch.append(epoch16_1)
-            cepoch = complex(epoch[0], epoch[1])
-            if (count == 1):
-                if (to_np == None):
-                    return cepoch
-                else:
-                    return np.array(cepoch)
-            else:
-                epochs.append(cepoch)
-        if (to_np == None):
-            return epochs
-        else:
-            return np.array(epochs)
-
-    def breakdown_epoch16(epochs, to_np=None):  # @NoSelf
-
-        if (isinstance(epochs, complex) or
-                isinstance(epochs, np.complex128)):
-            new_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
-            new_epochs = epochs
-        else:
-            print('Bad data')
-            return
-        count = len(new_epochs)
-        components = []
-        for x in range(0, count):
-            component = []
-            epoch16 = []
-            # complex
-            epoch16.append(new_epochs[x].real)
-            epoch16.append(new_epochs[x].imag)
-            if ((epoch16[0] == -1.0E31) and (epoch16[1] == -1.0E31)):
-                component.append(9999)
-                component.append(12)
-                component.append(31)
-                component.append(23)
-                component.append(59)
-                component.append(59)
-                component.append(999)
-                component.append(999)
-                component.append(999)
-                component.append(999)
-            else:
-                if (epoch16[0] < 0.0):
-                    epoch16[0] = -epoch16[0]
-                if (epoch16[1] < 0.0):
-                    epoch16[1] = -epoch16[1]
-                second_AD = epoch16[0]
-                minute_AD = second_AD / 60.0
-                hour_AD = minute_AD / 60.0
-                day_AD = hour_AD / 24.0
-                jd = int(1721060 + day_AD)
-                l = jd+68569
-                n = int(4*l/146097)
-                l = l-int((146097*n+3)/4)
-                i = int(4000*(l+1)/1461001)
-                l = l-int(1461*i/4)+31
-                j = int(80*l/2447)
-                k = l-int(2447*j/80)
-                l = int(j/11)
-                j = j+2-12*l
-                i = 100*(n-49)+i+l
-                component.append(i)
-                component.append(j)
-                component.append(k)
-                component.append(int(hour_AD % 24.0))
-                component.append(int(minute_AD % 60.0))
-                component.append(int(second_AD % 60.0))
-                msec = epoch16[1]
-                component_9 = int(msec % 1000.0)
-                msec = msec / 1000.0
-                component_8 = int(msec % 1000.0)
-                msec = msec / 1000.0
-                component_7 = int(msec % 1000.0)
-                msec = msec / 1000.0
-                component.append(int(msec))
-                component.append(component_7)
-                component.append(component_8)
-                component.append(component_9)
-            if (count == 1):
-                if (to_np == None):
-                    return component
-                else:
-                    return np.array(component)
-            else:
-                components.append(component)
-        if (to_np == None):
-            return components
-        else:
-            return np.array(components)
-
-    def _computeEpoch16(y, m, d, h, mn, s, ms, msu, msn, msp):  # @NoSelf
-
-        if (m == 0):
-            daysSince0AD = CDFepoch._JulianDay(y, 1, 1) + (d-1) - 1721060
-        else:
-            if (m < 0):
-                y = y - 1
-                m = 13 + m
-            daysSince0AD = CDFepoch._JulianDay(y, m, d) - 1721060
-        if (daysSince0AD < 0):
-            print('Illegal epoch')
-            return None
-        epoch = []
-        epoch.append(float(86400.0 * daysSince0AD + 3600.0 * h + 60.0 * mn) + float(s))
-        epoch.append(float(msp) + float(1000.0 * msn) + float(1000000.0 * msu) + math.pow(10.0, 9) * ms)
-        if (epoch[1] < 0.0 or epoch[1] >= math.pow(10.0, 12)):
-            if (epoch[1] < 0.0):
-                sec = int(epoch[1] / math.pow(10.0, 12))
-                tmp = epoch[1] - sec * math.pow(10.0, 12)
-                if (tmp != 0.0 and tmp != -0.0):
-                    epoch[0] = epoch[0] + sec - 1
-                    epoch[1] = math.pow(10.0, 12.0) + tmp
-                else:
-                    epoch[0] = epoch[0] + sec
-                    epoch[1] = 0.0
-            else:
-                sec = int(epoch[1] / math.pow(10.0, 12))
-                tmp = epoch[1] - sec * math.pow(10.0, 12)
-                if (tmp != 0.0 and tmp != -0.0):
-                    epoch[1] = tmp
-                    epoch[0] = epoch[0] + sec
-                else:
-                    epoch[1] = 0.0
-                    epoch[0] = epoch[0] + sec
-        if (epoch[0] < 0.0):
-            print('Illegal epoch')
-            return None
-        else:
-            return epoch
-
-    def epochrange_epoch16(epochs, starttime=None, endtime=None):  # @NoSelf
-
-        if (isinstance(epochs, complex) or isinstance(epochs, np.complex128)):
-            new_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
-            if (isinstance(epochs[0], complex) or
-                    isinstance(epochs[0], np.complex128)):
-                new_epochs = epochs
-            else:
-                print('Bad data')
-                return None
-        else:
-            print('Bad data')
-            return None
-        if (starttime == None):
-            stime = []
-            stime.append(-1.0E31)
-            stime.append(-1.0E31)
-        else:
-            if (isinstance(starttime, complex) or
-                    isinstance(starttime, np.complex128)):
-                stime = []
-                stime.append(starttime.real)
-                stime.append(starttime.imag)
-            elif (isinstance(starttime, list) or isinstance(starttime, tuple)):
-                sstime = CDFepoch.compute_epoch16(starttime)
-                stime = []
-                stime.append(sstime.real)
-                stime.append(sstime.imag)
-            else:
-                print('Bad start time')
-                return None
-        if (endtime != None):
-            if (isinstance(endtime, complex) or
-                    isinstance(endtime, np.complex128)):
-                etime = []
-                etime.append(endtime.real)
-                etime.append(endtime.imag)
-            elif (isinstance(endtime, list) or isinstance(endtime, tuple)):
-                eetime = CDFepoch.compute_epoch16(endtime)
-                etime = []
-                etime.append(eetime.real)
-                etime.append(eetime.imag)
-            else:
-                print('Bad start time')
-                return None
-        else:
-            etime = []
-            etime.append(1.0E31)
-            etime.append(1.0E31)
-        if (stime[0] > etime[0] or (stime[0] == etime[0] and stime[1] > etime[1])):
-            print('Invalid start/end time')
-            return None
-        count = len(new_epochs)
-        epoch16 = []
-        for x in range(0, count):
-            epoch16.append(new_epochs[x].real)
-            epoch16.append(new_epochs[x].imag)
-        count = count * 2
-        indx = []
-        if (epoch16[0] > etime[0] or (epoch16[0] == etime[0] and
-                                      epoch16[1] > etime[1])):
-            return None
-        if (epoch16[count-2] < stime[0] or
-            (epoch16[count-2] == stime[0] and
-             epoch16[count-1] < stime[1])):
-            return None
-        for x in range(0, count, 2):
-            if (epoch16[x] < stime[0]):
-                continue
-            elif (epoch16[x] == stime[0]):
-                if (epoch16[x+1] < stime[1]):
-                    continue
-                else:
-                    indx.append(int(x/2))
-                    break
-            else:
-                indx.append(int(x/2))
-                break
-        if (len(indx) == 0):
-            indx.append(0)
-        hasadded = False
-        for x in range(0, count, 2):
-            if (epoch16[x] < etime[0]):
-                continue
-            elif (epoch16[x] == etime[0]):
-                if (epoch16[x+1] > etime[1]):
-                    indx.append(int((x-1)/2))
-                    hasadded = True
-                    break
-            else:
-                indx.append(int((x-1)/2))
-                hasadded = True
-                break
-        if not hasadded:
-            indx.append(int(count/2)-1)
-        return np.arange(indx[0], indx[1]+1, step=1)
-
-    def encode_epoch(epochs, iso_8601=True):  # @NoSelf
-
-        if (isinstance(epochs, float) or isinstance(epochs, np.float64)):
-            new_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, np.ndarray)):
-            new_epochs = epochs
-        else:
-            print('Bad data')
-            return None
-        count = len(new_epochs)
-        encodeds = []
-        for x in range(0, count):
-            epoch = new_epochs[x]
-            if (epoch == -1.0E31):
-                if (iso_8601):
-                    encoded = '9999-12-31T23:59:59.999'
-                else:
-                    encoded = '31-Dec-9999 23:59:59.999'
-            else:
-                encoded = CDFepoch._encodex_epoch(epoch, iso_8601)
-            if (count == 1):
-                return encoded
             encodeds.append(encoded)
-        return encodeds
 
-    def _encodex_epoch(epoch, iso_8601=None):  # @NoSelf
+    return encodeds
 
-        components = CDFepoch.breakdown_epoch(epoch)
-        if (iso_8601):
-            # year-mm-ddThh:mm:ss.mmm
-            encoded = str(components[0]).zfill(4)
-            encoded += '-'
-            encoded += str(components[1]).zfill(2)
-            encoded += '-'
-            encoded += str(components[2]).zfill(2)
-            encoded += 'T'
-            encoded += str(components[3]).zfill(2)
-            encoded += ':'
-            encoded += str(components[4]).zfill(2)
-            encoded += ':'
-            encoded += str(components[5]).zfill(2)
-            encoded += '.'
-            encoded += str(components[6]).zfill(3)
+
+def _encodex_epoch16(epoch16: Sequence[complex], iso_8601: bool=True):
+
+    components = breakdown_epoch16(epoch16)
+    if iso_8601:
+        # year-mm-ddThh:mm:ss.mmmuuunnnppp
+        encoded = str(components[0]).zfill(4)
+        encoded += '-'
+        encoded += str(components[1]).zfill(2)
+        encoded += '-'
+        encoded += str(components[2]).zfill(2)
+        encoded += 'T'
+        encoded += str(components[3]).zfill(2)
+        encoded += ':'
+        encoded += str(components[4]).zfill(2)
+        encoded += ':'
+        encoded += str(components[5]).zfill(2)
+        encoded += '.'
+        encoded += str(components[6]).zfill(3)
+        encoded += str(components[7]).zfill(3)
+        encoded += str(components[8]).zfill(3)
+        encoded += str(components[9]).zfill(3)
+    else:
+        # dd-mmm-year hh:mm:ss.mmm.uuu.nnn.ppp
+        encoded = str(components[2]).zfill(2)
+        encoded += '-'
+        encoded += MONTH_TOKEN[components[1] - 1]
+        encoded += '-'
+        encoded += str(components[0]).zfill(4)
+        encoded += ' '
+        encoded += str(components[3]).zfill(2)
+        encoded += ':'
+        encoded += str(components[4]).zfill(2)
+        encoded += ':'
+        encoded += str(components[5]).zfill(2)
+        encoded += '.'
+        encoded += str(components[6]).zfill(3)
+        encoded += '.'
+        encoded += str(components[7]).zfill(3)
+        encoded += '.'
+        encoded += str(components[8]).zfill(3)
+        encoded += '.'
+        encoded += str(components[9]).zfill(3)
+    return encoded
+
+
+def breakdown_epoch16(epochs: Sequence[complex], to_np: bool=False):
+
+    if isinstance(epochs, (complex, np.complex128)):
+        new_epochs = [epochs]
+    elif isinstance(epochs, (list, tuple, np.ndarray)):
+        new_epochs = epochs
+    else:
+        raise TypeError('Bad input')
+
+    count = len(new_epochs)
+    components = []
+    for x in range(count):
+        component = []
+        epoch16 = []
+        # complex
+        epoch16.append(new_epochs[x].real)
+        epoch16.append(new_epochs[x].imag)
+        if ((epoch16[0] == -1.0E31) and (epoch16[1] == -1.0E31)):
+            component.append(9999)
+            component.append(12)
+            component.append(31)
+            component.append(23)
+            component.append(59)
+            component.append(59)
+            component.append(999)
+            component.append(999)
+            component.append(999)
+            component.append(999)
         else:
-            # dd-mmm-year hh:mm:ss.mmm
-            encoded = str(components[2]).zfill(2)
-            encoded += '-'
-            encoded += CDFepoch.month_Token[components[1]-1]
-            encoded += '-'
-            encoded += str(components[0]).zfill(4)
-            encoded += ' '
-            encoded += str(components[3]).zfill(2)
-            encoded += ':'
-            encoded += str(components[4]).zfill(2)
-            encoded += ':'
-            encoded += str(components[5]).zfill(2)
-            encoded += '.'
-            encoded += str(components[6]).zfill(3)
-        return encoded
-
-    def compute_epoch(dates, to_np=None):  # @NoSelf
-
-        if (not isinstance(dates, list) and not isinstance(dates, tuple)):
-            print('Bad input')
-            return None
-        if (not isinstance(dates[0], list) and not isinstance(dates[0], tuple)):
-            new_dates = []
-            new_dates = [dates]
-        else:
-            new_dates = dates
-        count = len(new_dates)
-        if (count == 0):
-            return None
-        epochs = []
-        for x in range(0, count):
-            date = new_dates[x]
-            year = date[0]
-            month = date[1]
-            items = len(date)
-            if (items > 6):
-                # y m d h m s ms
-                day = int(date[2])
-                hour = int(date[3])
-                minute = int(date[4])
-                second = int(date[5])
-                msec = int(date[6])
-            elif (items > 5):
-                # y m d h m s
-                day = int(date[2])
-                hour = int(date[3])
-                minute = int(date[4])
-                second = int(date[5])
-                msec = int(1000.0 * (date[5] - second))
-            elif (items > 4):
-                # y m d h m
-                day = int(date[2])
-                hour = int(date[3])
-                minute = int(date[4])
-                xxx = float(60.0 * (date[4] - minute))
-                second = int(xxx)
-                msec = int(1000.0 * (xxx - second))
-            elif (items > 3):
-                # y m d h
-                day = int(date[2])
-                hour = int(date[3])
-                xxx = float(60.0 * (date[3] - hour))
-                minute = int(xxx)
-                xxx = float(60.0 * (xxx - minute))
-                second = int(xxx)
-                msec = int(1000.0 * (xxx - second))
-            elif (items > 2):
-                # y m d
-                day = int(date[2])
-                xxx = float(24.0 * (date[2] - day))
-                hour = int(xxx)
-                xxx = float(60.0 * (xxx - hour))
-                minute = int(xxx)
-                xxx = float(60.0 * (xxx - minute))
-                second = int(xxx)
-                msec = int(1000.0 * (xxx - second))
+            if (epoch16[0] < 0.0):
+                epoch16[0] = -epoch16[0]
+            if (epoch16[1] < 0.0):
+                epoch16[1] = -epoch16[1]
+            second_AD = epoch16[0]
+            minute_AD = second_AD / 60.0
+            hour_AD = minute_AD / 60.0
+            day_AD = hour_AD / 24.0
+            jd = int(1721060 + day_AD)
+            L = jd + 68569
+            n = int(4 * L / 146097)
+            L = L - int((146097 * n + 3) / 4)
+            i = int(4000 * (L + 1) / 1461001)
+            L = L - int(1461 * i / 4) + 31
+            j = int(80 * L / 2447)
+            k = L - int(2447 * j / 80)
+            L = int(j / 11)
+            j = j + 2 - 12 * L
+            i = 100 * (n - 49) + i + L
+            component.append(i)
+            component.append(j)
+            component.append(k)
+            component.append(int(hour_AD % 24.0))
+            component.append(int(minute_AD % 60.0))
+            component.append(int(second_AD % 60.0))
+            msec = epoch16[1]
+            component_9 = int(msec % 1000.0)
+            msec = msec / 1000.0
+            component_8 = int(msec % 1000.0)
+            msec = msec / 1000.0
+            component_7 = int(msec % 1000.0)
+            msec = msec / 1000.0
+            component.append(int(msec))
+            component.append(component_7)
+            component.append(component_8)
+            component.append(component_9)
+        if count == 1:
+            if not to_np:
+                return component
             else:
-                print('Invalid epoch components')
-                return None
-            if (year == 9999 and month == 12 and day == 31 and hour == 23 and
-                    minute == 59 and second == 59 and msec == 999):
-                epochs.append(-1.0E31)
-            if (year < 0):
-                print('ILLEGAL_EPOCH_FIELD')
-                return None
-            if ((year > 9999) or (month < 0 or month > 12) or
-                (hour < 0 or hour > 23) or (minute < 0 or minute > 59) or
-                    (second < 0 or second > 59) or (msec < 0 or msec > 999)):
-                epochs.append(CDFepoch._computeEpoch(year, month, day, hour, minute,
-                                                     second, msec))
+                return np.array(component)
+        else:
+            components.append(component)
+    if not to_np:
+        return components
+    else:
+        return np.array(components)
+
+
+def encode_epoch(epochs: Sequence[float], iso_8601: bool=True) -> Union[str, List[str]]:
+
+    if isinstance(epochs, (float, np.float64)):
+        new_epochs = [epochs]
+    elif isinstance(epochs, (list, np.ndarray)):
+        new_epochs = epochs
+    else:
+        raise TypeError('Bad data')
+
+    count = len(new_epochs)
+    encodeds = []
+    for x in range(count):
+        epoch = new_epochs[x]
+        if epoch == -1.0E31:
+            encoded = '9999-12-31T23:59:59.999' if iso_8601 else '31-Dec-9999 23:59:59.999'
+        else:
+            encoded = _encodex_epoch(epoch, iso_8601)
+
+        if count == 1:
+            return encoded
+
+        encodeds.append(encoded)
+
+    return encodeds
+
+
+def _encodex_epoch(epoch: Sequence[float], iso_8601: bool=False) -> str:
+
+    components = breakdown_epoch(epoch)
+    if iso_8601:
+        # year-mm-ddThh:mm:ss.mmm
+        encoded = str(components[0]).zfill(4)
+        encoded += '-'
+        encoded += str(components[1]).zfill(2)
+        encoded += '-'
+        encoded += str(components[2]).zfill(2)
+        encoded += 'T'
+        encoded += str(components[3]).zfill(2)
+        encoded += ':'
+        encoded += str(components[4]).zfill(2)
+        encoded += ':'
+        encoded += str(components[5]).zfill(2)
+        encoded += '.'
+        encoded += str(components[6]).zfill(3)
+    else:
+        # dd-mmm-year hh:mm:ss.mmm
+        encoded = str(components[2]).zfill(2)
+        encoded += '-'
+        encoded += MONTH_TOKEN[components[1] - 1]
+        encoded += '-'
+        encoded += str(components[0]).zfill(4)
+        encoded += ' '
+        encoded += str(components[3]).zfill(2)
+        encoded += ':'
+        encoded += str(components[4]).zfill(2)
+        encoded += ':'
+        encoded += str(components[5]).zfill(2)
+        encoded += '.'
+        encoded += str(components[6]).zfill(3)
+
+    return encoded
+
+
+def breakdown_epoch(epochs: Sequence[float], to_np: bool=False) -> np.ndarray:
+
+    if isinstance(epochs, (float, np.float64)):
+        new_epochs = [epochs]
+    elif isinstance(epochs, (list, tuple, np.ndarray)):
+        new_epochs = epochs
+    else:
+        raise TypeError('Bad data')
+
+    count = len(new_epochs)
+    components = []
+    for x in range(count):
+        component = []
+        epoch = new_epochs[x]
+        if epoch == -1.0E31:
+            component.append(9999)
+            component.append(12)
+            component.append(31)
+            component.append(23)
+            component.append(59)
+            component.append(59)
+            component.append(999)
+        else:
+            if epoch < 0.:
+                epoch = -epoch
+
+            if isinstance(epochs, int):
+                epoch = float(epoch)
+
+            msec_AD = epoch
+            second_AD = msec_AD / 1000.0
+            minute_AD = second_AD / 60.0
+            hour_AD = minute_AD / 60.0
+            day_AD = hour_AD / 24.0
+            jd = int(1721060 + day_AD)
+            L = jd + 68569
+            n = int(4 * L / 146097)
+            L = L - int((146097 * n + 3) / 4)
+            i = int(4000 * (L + 1) / 1461001)
+            L = L - int(1461 * i / 4) + 31
+            j = int(80 * L / 2447)
+            k = L - int(2447 * j / 80)
+            L = int(j / 11)
+            j = j + 2 - 12 * L
+            i = 100 * (n - 49) + i + L
+            component.append(i)
+            component.append(j)
+            component.append(k)
+            component.append(int(hour_AD % 24.0))
+            component.append(int(minute_AD % 60.0))
+            component.append(int(second_AD % 60.0))
+            component.append(int(msec_AD % 1000.0))
+        if (count == 1):
+            if to_np:
+                return np.array(component)
+            else:
+                return component
+        else:
+            components.append(component)
+    if to_np:
+        return np.array(components)
+    else:
+        return components
+
+
+def compute_epoch16(datetimes, to_np: bool=False) -> np.ndarray:
+
+    if not isinstance(datetimes, (list, tuple)):
+        raise TypeError('Bad input')
+
+    new_dates = datetimes if isinstance(datetimes[0], (list, tuple)) else [datetimes]
+
+    count = len(new_dates)
+    if count == 0:
+        return None
+
+    epochs = []
+    for x in range(count):
+        epoch = []
+        date = new_dates[x]
+        items = len(date)
+        year = date[0]
+        month = date[1]
+        if (items > 9):
+            # y m d h m s ms us ns ps
+            day = int(date[2])
+            hour = int(date[3])
+            minute = int(date[4])
+            second = int(date[5])
+            msec = int(date[6])
+            usec = int(date[7])
+            nsec = int(date[8])
+            psec = int(date[9])
+        elif (items > 8):
+            # y m d h m s ms us ns
+            day = int(date[2])
+            hour = int(date[3])
+            minute = int(date[4])
+            second = int(date[5])
+            msec = int(date[6])
+            usec = int(date[7])
+            nsec = int(date[8])
+            psec = int(1000.0 * (date[8] - nsec))
+        elif (items > 7):
+            # y m d h m s ms us
+            day = int(date[2])
+            hour = int(date[3])
+            minute = int(date[4])
+            second = int(date[5])
+            msec = int(date[6])
+            usec = int(date[7])
+            xxx = int(1000.0 * (date[7] - usec))  # type: Union[float, int]
+            nsec = int(xxx)
+            psec = int(1000.0 * (xxx - nsec))
+        elif (items > 6):
+            # y m d h m s ms
+            day = int(date[2])
+            hour = int(date[3])
+            minute = int(date[4])
+            second = int(date[5])
+            msec = int(date[6])
+            xxx = float(1000.0 * (date[6] - msec))
+            usec = int(xxx)
+            xxx = int(1000.0 * (xxx - usec))
+            nsec = int(xxx)
+            psec = int(1000.0 * (xxx - nsec))
+        elif (items > 5):
+            # y m d h m s
+            day = int(date[2])
+            hour = int(date[3])
+            minute = int(date[4])
+            second = int(date[5])
+            xxx = float(1000.0 * (date[5] - second))
+            msec = int(xxx)
+            xxx = float(1000.0 * (xxx - msec))
+            usec = int(xxx)
+            xxx = int(1000.0 * (xxx - usec))
+            nsec = int(xxx)
+            psec = int(1000.0 * (xxx - nsec))
+        elif (items > 4):
+            # y m d h m
+            day = int(date[2])
+            hour = int(date[3])
+            minute = int(date[4])
+            xxx = float(60.0 * (date[4] - minute))
+            second = int(xxx)
+            xxx = float(1000.0 * (xxx - second))
+            msec = int(xxx)
+            xxx = float(1000.0 * (xxx - msec))
+            usec = int(xxx)
+            xxx = int(1000.0 * (xxx - usec))
+            nsec = int(xxx)
+            psec = int(1000.0 * (xxx - nsec))
+        elif (items > 3):
+            # y m d h
+            day = int(date[2])
+            hour = int(date[3])
+            xxx = float(60.0 * (date[3] - hour))
+            minute = int(xxx)
+            xxx = float(60.0 * (xxx - minute))
+            second = int(xxx)
+            xxx = float(1000.0 * (xxx - second))
+            msec = int(xxx)
+            xxx = float(1000.0 * (xxx - msec))
+            usec = int(xxx)
+            xxx = int(1000.0 * (xxx - usec))
+            nsec = int(xxx)
+            psec = int(1000.0 * (xxx - nsec))
+        elif (items > 2):
+            # y m d
+            day = int(date[2])
+            xxx = float(24.0 * (date[2] - day))
+            hour = int(xxx)
+            xxx = float(60.0 * (xxx - hour))
+            minute = int(xxx)
+            xxx = float(60.0 * (xxx - minute))
+            second = int(xxx)
+            xxx = float(1000.0 * (xxx - second))
+            msec = int(xxx)
+            xxx = float(1000.0 * (xxx - msec))
+            usec = int(xxx)
+            xxx = int(1000.0 * (xxx - usec))
+            nsec = int(xxx)
+            psec = int(1000.0 * (xxx - nsec))
+        else:
+            raise ValueError('Invalid epoch16 components')
+
+        if year < 0:
+            raise ValueError('Illegal epoch field')
+
+        if (year == 9999 and month == 12 and day == 31 and hour == 23 and
+            minute == 59 and second == 59 and msec == 999 and
+                usec == 999 and nsec == 999 and psec == 999):
+            epoch.append(-1.0E31)
+            epoch.append(-1.0E31)
+        elif ((year > 9999) or (month < 0 or month > 12) or
+              (hour < 0 or hour > 23) or (minute < 0 or minute > 59) or
+              (second < 0 or second > 59) or (msec < 0 or msec > 999) or
+              (usec < 0 or usec > 999) or (nsec < 0 or nsec > 999) or
+              (psec < 0 or psec > 999)):
+            epoch = _computeEpoch16(year, month, day, hour,
+                                    minute, second, msec,
+                                    usec, nsec, psec)
+        else:
             if (month == 0):
                 if (day < 1 or day > 366):
-                    epochs.append(CDFepoch._computeEpoch(year, month, day, hour,
-                                                         minute, second, msec))
+                    epoch = _computeEpoch16(year, month, day, hour,
+                                            minute, second, msec,
+                                            usec, nsec, psec)
             else:
                 if (day < 1 or day > 31):
-                    epochs.append(CDFepoch._computeEpoch(year, month, day, hour,
-                                                         minute, second, msec))
-            if (hour == 0 and minute == 0 and second == 0):
-                if (msec < 0 or msec > 86399999):
-                    epochs.append(CDFepoch._computeEpoch(year, month, day, hour,
-                                                         minute, second, msec))
-
+                    epoch = _computeEpoch16(year, month, day, hour,
+                                            minute, second, msec,
+                                            usec, nsec, psec)
             if (month == 0):
-                daysSince0AD = CDFepoch._JulianDay(year, 1, 1) + (day-1) - 1721060
+                daysSince0AD = _JulianDay(year, 1, 1) + (day - 1) - 1721060
             else:
-                daysSince0AD = CDFepoch._JulianDay(year, month, day) - 1721060
-            if (hour == 0 and minute == 0 and second == 0):
-                msecInDay = msec
+                daysSince0AD = _JulianDay(year, month, day) - 1721060
+            secInDay = (3600 * hour) + (60 * minute) + second
+            epoch16_0 = float(86400.0 * daysSince0AD) + float(secInDay)
+            epoch16_1 = float(psec) + float(1000.0 * nsec) + float(1000000.0 * usec) + float(1000000000.0 * msec)
+            epoch.append(epoch16_0)
+            epoch.append(epoch16_1)
+        cepoch = complex(epoch[0], epoch[1])
+        if count == 1:
+            if not to_np:
+                return cepoch
             else:
-                msecInDay = (3600000 * hour) + (60000 * minute) + (1000 * second) + msec
-            if (count == 1):
-                if (to_np == None):
-                    return (86400000.0*daysSince0AD+msecInDay)
-                else:
-                    return np.array((86400000.0*daysSince0AD+msecInDay))
-            epochs.append(86400000.0*daysSince0AD+msecInDay)
-        if (to_np == None):
-            return epochs
+                return np.array(cepoch)
         else:
-            return np.array(epochs)
+            epochs.append(cepoch)
 
-    def _computeEpoch(y, m, d, h, mn, s, ms):  # @NoSelf
+    if not to_np:
+        return epochs
+    else:
+        return np.array(epochs)
 
-        if (m == 0):
-            daysSince0AD = CDFepoch._JulianDay(y, 1, 1) + (d-1) - 1721060
+
+def _computeEpoch16(y: int, m: int, d: int, h: int, mn: int, s: int, ms: int, msu: int, msn: int, msp: int):
+
+    if (m == 0):
+        daysSince0AD = _JulianDay(y, 1, 1) + (d - 1) - 1721060
+    else:
+        if (m < 0):
+            y = y - 1
+            m = 13 + m
+        daysSince0AD = _JulianDay(y, m, d) - 1721060
+
+    if daysSince0AD < 0:
+        raise ValueError('Illegal epoch')
+
+    epoch = []
+    epoch.append(float(86400.0 * daysSince0AD + 3600.0 * h + 60.0 * mn) + float(s))
+    epoch.append(float(msp) + float(1000.0 * msn) + float(1000000.0 * msu) + 10.0**9 * ms)
+    if (epoch[1] < 0.0 or epoch[1] >= math.pow(10.0, 12)):
+        if (epoch[1] < 0.0):
+            sec = int(epoch[1] / math.pow(10.0, 12))
+            tmp = epoch[1] - sec * math.pow(10.0, 12)
+            if (tmp != 0.0 and tmp != -0.0):
+                epoch[0] = epoch[0] + sec - 1
+                epoch[1] = math.pow(10.0, 12.0) + tmp
+            else:
+                epoch[0] = epoch[0] + sec
+                epoch[1] = 0.0
         else:
-            if (m < 0):
-                --y
-                m = 13 + m
-            daysSince0AD = CDFepoch._JulianDay(y, m, d) - 1721060
-        if (daysSince0AD < 1):
+            sec = int(epoch[1] / math.pow(10.0, 12))
+            tmp = epoch[1] - sec * math.pow(10.0, 12)
+            if (tmp != 0.0 and tmp != -0.0):
+                epoch[1] = tmp
+                epoch[0] = epoch[0] + sec
+            else:
+                epoch[1] = 0.0
+                epoch[0] = epoch[0] + sec
+
+    if (epoch[0] < 0.0):
+        raise ValueError('Illegal epoch')
+
+    return epoch
+
+
+def compute_epoch(dates: Sequence[Sequence[int]], to_np: bool=False):
+
+    if not isinstance(dates, (list, tuple)):
+        raise TypeError('Bad input')
+
+    new_dates = dates if isinstance(dates[0], (list, tuple)) else [dates]
+
+    count = len(new_dates)
+    if count == 0:
+        return None
+
+    epochs = []
+    for x in range(count):
+        date = new_dates[x]
+        year = date[0]
+        month = date[1]
+        items = len(date)
+        if (items > 6):
+            # y m d h m s ms
+            day = int(date[2])
+            hour = int(date[3])
+            minute = int(date[4])
+            second = int(date[5])
+            msec = int(date[6])
+        elif (items > 5):
+            # y m d h m s
+            day = int(date[2])
+            hour = int(date[3])
+            minute = int(date[4])
+            second = int(date[5])
+            msec = int(1000.0 * (date[5] - second))
+        elif (items > 4):
+            # y m d h m
+            day = int(date[2])
+            hour = int(date[3])
+            minute = int(date[4])
+            xxx = float(60.0 * (date[4] - minute))
+            second = int(xxx)
+            msec = int(1000.0 * (xxx - second))
+        elif (items > 3):
+            # y m d h
+            day = int(date[2])
+            hour = int(date[3])
+            xxx = float(60.0 * (date[3] - hour))
+            minute = int(xxx)
+            xxx = float(60.0 * (xxx - minute))
+            second = int(xxx)
+            msec = int(1000.0 * (xxx - second))
+        elif (items > 2):
+            # y m d
+            day = int(date[2])
+            xxx = float(24.0 * (date[2] - day))
+            hour = int(xxx)
+            xxx = float(60.0 * (xxx - hour))
+            minute = int(xxx)
+            xxx = float(60.0 * (xxx - minute))
+            second = int(xxx)
+            msec = int(1000.0 * (xxx - second))
+        else:
+            print('Invalid epoch components')
+            return None
+        if (year == 9999 and month == 12 and day == 31 and hour == 23 and
+                minute == 59 and second == 59 and msec == 999):
+            epochs.append(-1.0E31)
+        if (year < 0):
             print('ILLEGAL_EPOCH_FIELD')
             return None
-        msecInDay = float(3600000.0 * h + 60000.0 * mn + 1000.0 * s) + float(ms)
-        msecFromEpoch = float(86400000.0 * daysSince0AD + msecInDay)
-        if (msecFromEpoch < 0.0):
-            return -1.0
+        if (year > 9999 or not 0 <= month <= 12 or
+            not 0 <= hour <= 23 or not 0 <= minute <= 59 or
+                not 0 <= second <= 59 or 0 <= msec <= 999):
+            epochs.append(_computeEpoch(year, month, day, hour, minute,
+                                        second, msec))
+        if month == 0:
+            if not 1 <= day <= 366:
+                epochs.append(_computeEpoch(year, month, day, hour,
+                                            minute, second, msec))
         else:
-            return msecFromEpoch
+            if not 1 <= day <= 31:
+                epochs.append(_computeEpoch(year, month, day, hour,
+                                            minute, second, msec))
+        if (hour == 0 and minute == 0 and second == 0):
+            if not 0 <= msec <= 86399999:
+                epochs.append(_computeEpoch(year, month, day, hour,
+                                            minute, second, msec))
 
-    def breakdown_epoch(epochs, to_np=False):  # @NoSelf
-
-        if (isinstance(epochs, float) or isinstance(epochs, np.float64)):
-            new_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
-            new_epochs = epochs
+        if (month == 0):
+            daysSince0AD = _JulianDay(year, 1, 1) + (day - 1) - 1721060
         else:
-            print('Bad data')
-            return None
-        count = len(new_epochs)
-        components = []
-        for x in range(0, count):
-            component = []
-            epoch = new_epochs[x]
-            if (epoch == -1.0E31):
-                component.append(9999)
-                component.append(12)
-                component.append(31)
-                component.append(23)
-                component.append(59)
-                component.append(59)
-                component.append(999)
+            daysSince0AD = _JulianDay(year, month, day) - 1721060
+        if (hour == 0 and minute == 0 and second == 0):
+            msecInDay = msec
+        else:
+            msecInDay = (3600000 * hour) + (60000 * minute) + (1000 * second) + msec
+        if (count == 1):
+            if not to_np:
+                return 86400000.0 * daysSince0AD + msecInDay
             else:
-                if (epoch < 0.0):
-                    epoch = -epochs
-                if (isinstance(epochs, int)):
-                    epoch = float(epoch)
-                msec_AD = epoch
-                second_AD = msec_AD / 1000.0
-                minute_AD = second_AD / 60.0
-                hour_AD = minute_AD / 60.0
-                day_AD = hour_AD / 24.0
-                jd = int(1721060 + day_AD)
-                l = jd+68569
-                n = int(4*l/146097)
-                l = l-int((146097*n+3)/4)
-                i = int(4000*(l+1)/1461001)
-                l = l-int(1461*i/4)+31
-                j = int(80*l/2447)
-                k = l-int(2447*j/80)
-                l = int(j/11)
-                j = j+2-12*l
-                i = 100*(n-49)+i+l
-                component.append(i)
-                component.append(j)
-                component.append(k)
-                component.append(int(hour_AD % 24.0))
-                component.append(int(minute_AD % 60.0))
-                component.append(int(second_AD % 60.0))
-                component.append(int(msec_AD % 1000.0))
-            if (count == 1):
-                if (to_np):
-                    return np.array(component)
-                else:
-                    return component
-            else:
-                components.append(component)
-        if (to_np):
-            return np.array(components)
-        else:
-            return components
+                return np.array((86400000.0 * daysSince0AD + msecInDay))
+        epochs.append(86400000.0 * daysSince0AD + msecInDay)
+    if (not to_np):
+        return epochs
+    else:
+        return np.array(epochs)
 
-    def epochrange_epoch(epochs, starttime=None, endtime=None):  # @NoSelf
 
-        if (isinstance(epochs, float) or isinstance(epochs, np.float64)):
-            new2_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
-            if (isinstance(epochs[0], float) or
-                    isinstance(epochs[0], np.float64)):
-                new2_epochs = epochs
-            else:
-                print('Bad data')
-                return None
-        else:
-            print('Bad data')
-            return None
-        if (starttime == None):
-            stime = 0.0
-        else:
-            if (isinstance(starttime, float) or isinstance(starttime, int) or
-                    isinstance(starttime, np.float64)):
-                stime = starttime
-            elif (isinstance(starttime, list) or isinstance(starttime, tuple)):
-                stime = CDFepoch.compute_epoch(starttime)
-            else:
-                print('Bad start time')
-                return None
-        if (endtime != None):
-            if (isinstance(endtime, float) or isinstance(endtime, int) or
-                    isinstance(endtime, np.float64)):
-                etime = endtime
-            elif (isinstance(endtime, list) or isinstance(endtime, tuple)):
-                etime = CDFepoch.compute_epoch(endtime)
-            else:
-                print('Bad end time')
-                return None
-        else:
-            etime = 1.0E31
-        if (stime > etime):
-            print('Invalid start/end time')
-            return None
-        if (isinstance(epochs, list) or isinstance(epochs, tuple)):
-            new_epochs = np.array(epochs)
-        else:
-            new_epochs = epochs
-        return np.where(np.logical_and(new_epochs >= stime, new_epochs <= etime))[0]
+def _computeEpoch(y: int, m: int, d: int, h: int, mn: int, s: int, ms: float):
 
-    def parse(value, to_np=None):  # @NoSelf
-        """
-        Parses the provided date/time string(s) into CDF epoch value(s).
+    if (m == 0):
+        daysSince0AD = _JulianDay(y, 1, 1) + (d - 1) - 1721060
+    else:
+        if (m < 0):
+            --y
+            m = 13 + m
+        daysSince0AD = _JulianDay(y, m, d) - 1721060
+    if (daysSince0AD < 1):
+        print('ILLEGAL_EPOCH_FIELD')
+        return None
+    msecInDay = float(3600000.0 * h + 60000.0 * mn + 1000.0 * s) + float(ms)
+    msecFromEpoch = float(86400000.0 * daysSince0AD + msecInDay)
 
-        For CDF_EPOCH:
-                The string has to be in the form of 'dd-mmm-yyyy hh:mm:ss.xxx' or
-                'yyyy-mm-ddThh:mm:ss.xxx' (in iso_8601). The string is the output
-                from encode function.
+    if msecFromEpoch < 0.0:
+        return -1.0
+    else:
+        return msecFromEpoch
 
-        For CDF_EPOCH16:
-                The string has to be in the form of
-                'dd-mmm-yyyy hh:mm:ss.mmm.uuu.nnn.ppp' or
-                'yyyy-mm-ddThh:mm:ss.mmmuuunnnppp' (in iso_8601). The string is
-                the output from encode function.
 
-        For TT2000:
-                The string has to be in the form of
-                'dd-mmm-yyyy hh:mm:ss.mmm.uuu.nnn' or
-                'yyyy-mm-ddThh:mm:ss.mmmuuunnn' (in iso_8601). The string is
-                the output from encode function.
+def _JulianDay(y: int, m: int, d: int) -> int:
 
-        Specify to_np to True, if the result should be in numpy class.
-        """
-        if ((isinstance(value, list) or isinstance(value, tuple)) and
-                not (isinstance(value[0], str))):
-            print('Invalid value... should be a string or a list of string')
-            return None
-        elif ((not (isinstance(value, list))) and
-              (not (isinstance(value, tuple))) and
-              (not (isinstance(value, str)))):
-            print('Invalid value... should be a string or a list of string')
-            return None
-        else:
-            if (isinstance(value, list) or isinstance(value, tuple)):
-                num = len(value)
-                epochs = []
-                for x in range(0, num):
-                    epochs.append(CDFepoch._parse_epoch(value[x]))
-                if (to_np == None):
-                    return epochs
-                else:
-                    return np.array(epochs)
-            else:
-                if (to_np == None):
-                    return CDFepoch._parse_epoch(value)
-                else:
-                    return np.array(CDFepoch._parse_epoch(value))
+    a1 = int(7 * (int(y + int((m + 9) / 12))) / 4)
+    a2 = int(3 * (int(int(y + int((m - 9) / 7)) / 100) + 1) / 4)
+    a3 = int(275 * m / 9)
+    return (367 * y - a1 - a2 + a3 + d + 1721029)
 
-    def _parse_epoch(value):  # @NoSelf
-        if (isinstance(value, list) or isinstance(value, tuple)):
-            epochs = []
-            for x in range(0, len(value)):
-                epochs.append(value[x])
-            return epochs
-        else:
-            if (len(value) == 23 or len(value) == 24):
-                # CDF_EPOCH
-                if (value.lower() == '31-dec-9999 23:59:59.999' or
-                        value.lower() == '9999-12-31t23:59:59.999'):
-                    return -1.0E31
-                else:
-                    if (len(value) == 24):
-                        date = re.findall('(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)', value)
-                        dd = int(date[0][0])
-                        mm = CDFepoch._month_index(date[0][1])
-                        yy = int(date[0][2])
-                        hh = int(date[0][3])
-                        mn = int(date[0][4])
-                        ss = int(date[0][5])
-                        ms = int(date[0][6])
-                    else:
-                        date = re.findall('(\d+)\-(\d+)\-(\d+)T(\d+)\:(\d+)\:(\d+)\.(\d+)',
-                                          value)
-                        yy = int(date[0][0])
-                        mm = int(date[0][1])
-                        dd = int(date[0][2])
-                        hh = int(date[0][3])
-                        mn = int(date[0][4])
-                        ss = int(date[0][5])
-                        ms = int(date[0][6])
-                    return CDFepoch.compute_epoch([yy, mm, dd, hh, mn, ss, ms])
-            elif (len(value) == 36 or (len(value) == 32 and
-                                       value[10].lower() == 't')):
-                # CDF_EPOCH16
-                if (value.lower() == '31-dec-9999 23:59:59.999.999.999.999' or
-                        value.lower() == '9999-12-31t23:59:59.999999999999'):
-                    return -1.0E31-1.0E31j
-                else:
-                    if (len(value) == 36):
-                        date = re.findall('(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)\.(\d+)\.(\d+)\.(\d+)',
-                                          value)
-                        dd = int(date[0][0])
-                        mm = CDFepoch._month_index(date[0][1])
-                        yy = int(date[0][2])
-                        hh = int(date[0][3])
-                        mn = int(date[0][4])
-                        ss = int(date[0][5])
-                        ms = int(date[0][6])
-                        us = int(date[0][7])
-                        ns = int(date[0][8])
-                        ps = int(date[0][9])
-                    else:
-                        date = re.findall('(\d+)\-(\d+)\-(\d+)T(\d+)\:(\d+)\:(\d+)\.(\d+)',
-                                          value)
-                        yy = int(date[0][0])
-                        mm = int(date[0][1])
-                        dd = int(date[0][2])
-                        hh = int(date[0][3])
-                        mn = int(date[0][4])
-                        ss = int(date[0][5])
-                        subs = int(date[0][6])
-                        ms = int(subs / 1000000000)
-                        subms = int(subs % 1000000000)
-                        us = int(subms / 1000000)
-                        subus = int(subms % 1000000)
-                        ns = int(subus / 1000)
-                        ps = int(subus % 1000)
-                    return CDFepoch.compute_epoch16([yy, mm, dd, hh, mn, ss, ms, us, ns, ps])
-            elif (len(value) == 29 or (len(value) == 32 and
-                                       value[11] == ' ')):
-                # CDF_TIME_TT2000
-                value = value.lower()
-                if (value == '9999-12-31t23:59:59.999999999' or
-                        value == '31-dec-9999 23:59:59.999.999.999'):
-                    return -9223372036854775808
-                elif (value == '0000-01-01t00:00.000000000' or
-                      value == '01-jan-0000 00:00.000.000.000'):
-                    return -9223372036854775807
-                else:
-                    if (len(value) == 29):
-                        date = re.findall('(\d+)\-(\d+)\-(\d+)t(\d+)\:(\d+)\:(\d+)\.(\d+)',
-                                          value)
-                        yy = int(date[0][0])
-                        mm = int(date[0][1])
-                        dd = int(date[0][2])
-                        hh = int(date[0][3])
-                        mn = int(date[0][4])
-                        ss = int(date[0][5])
-                        subs = int(date[0][6])
-                        ms = int(subs / 1000000)
-                        subms = int(subs % 1000000)
-                        us = int(subms / 1000)
-                        ns = int(subms % 1000)
-                    else:
-                        date = re.findall('(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)\.(\d+)\.(\d+)',
-                                          value)
-                        dd = int(date[0][0])
-                        mm = CDFepoch._month_index(date[0][1])
-                        yy = int(date[0][2])
-                        hh = int(date[0][3])
-                        mn = int(date[0][4])
-                        ss = int(date[0][5])
-                        ms = int(date[0][6])
-                        us = int(date[0][7])
-                        ns = int(date[0][8])
-                    return CDFepoch.compute_tt2000([yy, mm, dd, hh, mn, ss, ms, us, ns])
-            else:
-                print('Invalid cdf epoch type...')
-                return None
 
-    def _month_index(month):  # @NoSelf
-        if (month.lower() == 'jan'):
-            return 1
-        elif(month.lower() == 'feb'):
-            return 2
-        elif(month.lower() == 'mar'):
-            return 3
-        elif(month.lower() == 'apr'):
-            return 4
-        elif(month.lower() == 'may'):
-            return 5
-        elif(month.lower() == 'jun'):
-            return 6
-        elif(month.lower() == 'jul'):
-            return 7
-        elif(month.lower() == 'aug'):
-            return 8
-        elif(month.lower() == 'sep'):
-            return 9
-        elif(month.lower() == 'oct'):
-            return 10
-        elif(month.lower() == 'nov'):
-            return 11
-        elif(month.lower() == 'dec'):
-            return 12
-        else:
-            return -1
-
-    def getVersion():  # @NoSelf
-        """
-        Shows the code version.
-        """
-        print('epochs version:', str(CDFepoch.version) + '.' +
-              str(CDFepoch.release) + '.'+str(CDFepoch.increment))
-
-    def getLeapSecondLastUpdated():  # @NoSelf
-        """
-        Shows the latest date a leap second was added to the leap second table.
-        """
-        print('Leap second last updated:', str(CDFepoch.LTS[-1][0]) + '-' +
-              str(CDFepoch.LTS[-1][1]) + '-' + str(CDFepoch.LTS[-1][2]))
+def _month_index(month: str) -> int:
+    return datetime.datetime.strptime(month, '%b').month

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cdflib
-version = 0.3.5
+version = 0.3.6
 author = MAVEN SDC
 author_email = mavensdc@lasp.colorado.edu
 description = A python CDF reader toolkit

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
 [options.extras_require]
 tests =
   pytest
+cov =
   pytest-cov
   coveralls
   flake8

--- a/tests/test_cdfwrite.py
+++ b/tests/test_cdfwrite.py
@@ -48,8 +48,9 @@ def test_checksum():
 # %% Open the file to read
     reader = cdfread.CDF(fncsum, validate=True)
     # Test CDF info
-    var = reader.varget("Variable1")
-    assert (var == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).all()
+    assert (reader.varget("Variable1") == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).all()
+# %% test convenience read
+    assert (reader["Variable1"] == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).all()
 
 
 def test_checksum_compressed():
@@ -567,4 +568,4 @@ def test_create_2d_r_and_z_variables():
 
 
 if __name__ == '__main__':
-    pytest.main(['-x', __file__])
+    pytest.main(['-xrsv', __file__])

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 import pytest
-import unittest
 import numpy as np
 import cdflib
 from random import randint
-
+from pytest import approx
 '''
 To check code coverage, first:
 
@@ -24,219 +23,229 @@ Each of these results were hand checked using either IDL or
 other online resources.
 '''
 
+CDFepoch = cdflib.cdfepoch()
 
-def test_encode_cdfepoch():
-    x = cdflib.cdfepoch.encode([62285326000000.0, 62985326000000.0])
+
+def test_encode_CDFepoch():
+    x = CDFepoch.encode([62285326000000.0, 62985326000000.0])
     assert x[0] == '1973-09-28T23:26:40.000'
     assert x[1] == '1995-12-04T19:53:20.000'
 
-    y = cdflib.cdfepoch.encode(62975326000002.0, iso_8601=False)
+    y = CDFepoch.encode(62975326000002.0, iso_8601=False)
     assert y == '11-Aug-1995 02:06:40.002'
 
 
-class CDFEpochTestCase(unittest.TestCase):
+def test_encode_CDFepoch16():
+    '''
+    cdf_encode_epoch16(dcomplex(63300946758.000000, 176214648000.00000)) in IDL
+    returns 04-Dec-2005 20:39:28.176.214.654.976
 
-    def test_encode_cdfepoch16(self):
-        '''
-        cdf_encode_epoch16(dcomplex(63300946758.000000, 176214648000.00000)) in IDL
-        returns 04-Dec-2005 20:39:28.176.214.654.976
+    However, I believe this IDL routine is bugged.  This website:
+    https://www.epochconverter.com/seconds-days-since-y0
 
-        However, I believe this IDL routine is bugged.  This website:
-        https://www.epochconverter.com/seconds-days-since-y0
+    shows a correct answer.
+    '''
+    x = CDFepoch.encode(np.complex128(63300946758.000000 + 176214648000.00000j))
+    assert x == '2005-12-04T20:19:18.176214648000'
+    y = CDFepoch.encode(np.complex128([33300946758.000000 + 106014648000.00000j,
+                                       61234543210.000000 + 000011148000.00000j]),
+                        iso_8601=False)
+    assert y[0] == '07-Apr-1055 14:59:18.106.014.648.000'
+    assert y[1] == '12-Jun-1940 03:20:10.000.011.148.000'
 
-        shows a correct answer.
-        '''
-        x = cdflib.cdfepoch.encode(np.complex128(63300946758.000000 + 176214648000.00000j))
-        self.assertEqual(x, '2005-12-04T20:19:18.176214648000')
-        y = cdflib.cdfepoch.encode(np.complex128([33300946758.000000 + 106014648000.00000j,
-                                                  61234543210.000000 + 000011148000.00000j]),
-                                   iso_8601=False)
-        self.assertEqual(y[0], '07-Apr-1055 14:59:18.106.014.648.000')
-        self.assertEqual(y[1], '12-Jun-1940 03:20:10.000.011.148.000')
 
-    def test_encode_cdftt2000(self):
-        x = cdflib.cdfepoch.encode(186999622360321123)
-        self.assertEqual(x, '2005-12-04T20:19:18.176321123')
-        y = cdflib.cdfepoch.encode([500000000100, 123456789101112131],
-                                   iso_8601=False)
-        self.assertEqual(y[0], '01-Jan-2000 12:07:15.816.000.100')
-        self.assertEqual(y[1], '30-Nov-2003 09:32:04.917.112.131')
+def test_encode_cdftt2000():
+    x = CDFepoch.encode(186999622360321123)
+    assert x == '2005-12-04T20:19:18.176321123'
 
-    def test_unixtime(self):
-        x = cdflib.cdfepoch.unixtime([500000000100, 123456789101112131])
-        self.assertEqual(x[0], 946728435.816)
-        self.assertEqual(x[1], 1070184724.917112)
+    y = CDFepoch.encode([500000000100, 123456789101112131], iso_8601=False)
+    assert y[0] == '01-Jan-2000 12:07:15.816.000.100'
+    assert y[1] == '30-Nov-2003 09:32:04.917.112.131'
 
-    def test_breakdown_cdfepoch(self):
-        x = cdflib.cdfepoch.breakdown([62285326000000.0, 62985326000000.0])
-        # First in the array
-        self.assertEqual(x[0][0], 1973)
-        self.assertEqual(x[0][1], 9)
-        self.assertEqual(x[0][2], 28)
-        self.assertEqual(x[0][3], 23)
-        self.assertEqual(x[0][4], 26)
-        self.assertEqual(x[0][5], 40)
-        self.assertEqual(x[0][6], 0)
-        # Second in the array
-        self.assertEqual(x[1][0], 1995)
-        self.assertEqual(x[1][1], 12)
-        self.assertEqual(x[1][2], 4)
-        self.assertEqual(x[1][3], 19)
-        self.assertEqual(x[1][4], 53)
-        self.assertEqual(x[1][5], 20)
-        self.assertEqual(x[1][6], 0)
 
-    def test_breakdown_cdfepoch16(self):
-        x = cdflib.cdfepoch.breakdown(np.complex128(63300946758.000000 + 176214648000.00000j))
-        self.assertEqual(x[0], 2005)
-        self.assertEqual(x[1], 12)
-        self.assertEqual(x[2], 4)
-        self.assertEqual(x[3], 20)
-        self.assertEqual(x[4], 19)
-        self.assertEqual(x[5], 18)
-        self.assertEqual(x[6], 176)
-        self.assertEqual(x[7], 214)
-        self.assertEqual(x[8], 648)
-        self.assertEqual(x[9], 000)
+def test_unixtime():
+    x = CDFepoch.unixtime([500000000100, 123456789101112131])
+    assert x[0] == approx(946728435.816)
+    assert x[1] == approx(1070184724.917112)
 
-    def test_breakdown_cdftt2000(self):
-        x = cdflib.cdfepoch.breakdown(123456789101112131)
-        self.assertEqual(x[0], 2003)
-        self.assertEqual(x[1], 11)
-        self.assertEqual(x[2], 30)
-        self.assertEqual(x[3], 9)
-        self.assertEqual(x[4], 32)
-        self.assertEqual(x[5], 4)
-        self.assertEqual(x[6], 917)
-        self.assertEqual(x[7], 112)
-        self.assertEqual(x[8], 131)
 
-    def test_compute_cdfepoch(self):
-        '''
-        Using random numbers for the compute tests
-        '''
-        random_time = []
-        random_time.append(randint(0, 2018))  # Year
-        random_time.append(randint(1, 12))  # Month
-        random_time.append(randint(1, 28))  # Date
-        random_time.append(randint(0, 23))  # Hour
-        random_time.append(randint(0, 59))  # Minute
-        random_time.append(randint(0, 59))  # Second
-        random_time.append(randint(0, 999))  # Millisecond
-        x = cdflib.cdfepoch.breakdown(cdflib.cdfepoch.compute(random_time))
-        i = 0
-        for t in x:
-            self.assertEqual(t, random_time[i], 'Time '+str(random_time) + ' was not equal to ' + str(x))
-            i += 1
+def test_breakdown_CDFepoch():
+    x = CDFepoch.breakdown([62285326000000.0, 62985326000000.0])
+    # First in the array
+    assert x[0][0] == 1973
+    assert x[0][1] == 9
+    assert x[0][2] == 28
+    assert x[0][3] == 23
+    assert x[0][4] == 26
+    assert x[0][5] == 40
+    assert x[0][6] == 0
+    # Second in the array
+    assert x[1][0] == 1995
+    assert x[1][1] == 12
+    assert x[1][2] == 4
+    assert x[1][3] == 19
+    assert x[1][4] == 53
+    assert x[1][5] == 20
+    assert x[1][6] == 0
 
-    def test_compute_cdfepoch16(self):
-        random_time = []
-        random_time.append(randint(0, 2018))  # Year
-        random_time.append(randint(1, 12))  # Month
-        random_time.append(randint(1, 28))  # Date
-        random_time.append(randint(0, 23))  # Hour
-        random_time.append(randint(0, 59))  # Minute
-        random_time.append(randint(0, 59))  # Second
-        random_time.append(randint(0, 999))  # Millisecond
-        random_time.append(randint(0, 999))  # Microsecond
-        random_time.append(randint(0, 999))  # Nanosecond
-        random_time.append(randint(0, 999))  # Picosecond
-        x = cdflib.cdfepoch.breakdown(cdflib.cdfepoch.compute(random_time))
-        i = 0
-        for t in x:
-            self.assertEqual(t, random_time[i], 'Time '+str(random_time) + ' was not equal to ' + str(x))
-            i += 1
 
-    def test_compute_cdftt2000(self):
-        random_time = []
-        random_time.append(randint(0, 2018))  # Year
-        random_time.append(randint(1, 12))  # Month
-        random_time.append(randint(1, 28))  # Date
-        random_time.append(randint(0, 23))  # Hour
-        random_time.append(randint(0, 59))  # Minute
-        random_time.append(randint(0, 59))  # Second
-        random_time.append(randint(0, 999))  # Millisecond
-        random_time.append(randint(0, 999))  # Microsecond
-        random_time.append(randint(0, 999))  # Nanosecond
-        x = cdflib.cdfepoch.breakdown(cdflib.cdfepoch.compute(random_time))
-        i = 0
-        for t in x:
-            self.assertEqual(t, random_time[i], 'Time '+str(random_time) + ' was not equal to ' + str(x))
-            i += 1
+def test_breakdown_CDFepoch16():
+    x = CDFepoch.breakdown(np.complex128(63300946758.000000 + 176214648000.00000j))
+    assert x[0] == 2005
+    assert x[1] == 12
+    assert x[2] == 4
+    assert x[3] == 20
+    assert x[4] == 19
+    assert x[5] == 18
+    assert x[6] == 176
+    assert x[7] == 214
+    assert x[8] == 648
+    assert x[9] == 0
 
-    def test_parse_cdfepoch(self):
-        x = cdflib.cdfepoch.encode(62567898765432.0)
-        self.assertEqual(x, "1982-09-12T11:52:45.432")
-        parsed = cdflib.cdfepoch.parse(x)
-        self.assertEqual(parsed, 62567898765432.0)
 
-    def test_parse_cdfepoch16(self):
-        input_time = np.complex(53467976543.0, 543218654100)
-        x = cdflib.cdfepoch.encode(input_time)
-        self.assertEqual(x, "1694-05-01T07:42:23.543218654100")
-        parsed = cdflib.cdfepoch.parse(x, to_np=True)
-        self.assertEqual(parsed, input_time)
+def test_breakdown_cdftt2000():
+    x = CDFepoch.breakdown(123456789101112131)
+    assert x[0] == 2003
+    assert x[1] == 11
+    assert x[2] == 30
+    assert x[3] == 9
+    assert x[4] == 32
+    assert x[5] == 4
+    assert x[6] == 917
+    assert x[7] == 112
+    assert x[8] == 131
 
-    def test_parse_cdftt2000(self):
-        input_time = 131415926535793238
-        x = cdflib.cdfepoch.encode(input_time)
-        self.assertEqual(x, "2004-03-01T12:24:22.351793238")
-        parsed = cdflib.cdfepoch.parse(x)
-        self.assertEqual(parsed, input_time)
 
-    def test_findepochrange_cdfepoch(self):
-        start_time = "2013-12-01T12:24:22.000"
-        end_time = "2014-12-01T12:24:22.000"
-        x = cdflib.cdfepoch.parse([start_time, end_time])
-        time_array = np.arange(x[0], x[1], step=1000000)
+def test_compute_CDFepoch():
+    '''
+    Using random numbers for the compute tests
+    '''
+    random_time = []
+    random_time.append(randint(0, 2018))  # Year
+    random_time.append(randint(1, 12))  # Month
+    random_time.append(randint(1, 28))  # Date
+    random_time.append(randint(0, 23))  # Hour
+    random_time.append(randint(0, 59))  # Minute
+    random_time.append(randint(0, 59))  # Second
+    random_time.append(randint(0, 999))  # Millisecond
+    x = CDFepoch.breakdown(CDFepoch.compute(random_time))
+    for i, t in enumerate(x):
+        assert t == random_time[i]
 
-        test_start = [2014, 8, 1, 8, 1, 54, 123]
-        test_end = [2018, 1, 1, 1, 1, 1, 1]
-        index = cdflib.cdfepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
-        # Test that the test_start is less than the first index, but more than one less
-        self.assertGreaterEqual(time_array[index[0]], cdflib.cdfepoch.compute(test_start))
-        self.assertLessEqual(time_array[index[0]-1], cdflib.cdfepoch.compute(test_start))
 
-        self.assertLessEqual(time_array[index[-1]], cdflib.cdfepoch.compute(test_end))
-        return
+def test_compute_CDFepoch16():
+    random_time = []
+    random_time.append(randint(0, 2018))  # Year
+    random_time.append(randint(1, 12))  # Month
+    random_time.append(randint(1, 28))  # Date
+    random_time.append(randint(0, 23))  # Hour
+    random_time.append(randint(0, 59))  # Minute
+    random_time.append(randint(0, 59))  # Second
+    random_time.append(randint(0, 999))  # Millisecond
+    random_time.append(randint(0, 999))  # Microsecond
+    random_time.append(randint(0, 999))  # Nanosecond
+    random_time.append(randint(0, 999))  # Picosecond
+    x = CDFepoch.breakdown(CDFepoch.compute(random_time))
+    for i, t in enumerate(x):
+        t == random_time[i]
 
-    def test_findepochrange_cdftt2000(self):
-        start_time = "2004-03-01T12:24:22.351793238"
-        end_time = "2004-03-01T12:28:22.351793238"
-        x = cdflib.cdfepoch.parse([start_time, end_time])
-        time_array = np.arange(x[0], x[1], step=1000000)
 
-        test_start = [2004, 3, 1, 12, 25, 54, 123, 111, 98]
-        test_end = [2004, 3, 1, 12, 26, 4, 123, 456, 789]
-        index = cdflib.cdfepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
-        # Test that the test_start is less than the first index, but more than one less
-        self.assertGreaterEqual(time_array[index[0]], cdflib.cdfepoch.compute(test_start))
-        self.assertLessEqual(time_array[index[0]-1], cdflib.cdfepoch.compute(test_start))
+def test_compute_cdftt2000():
+    random_time = []
+    random_time.append(randint(0, 2018))  # Year
+    random_time.append(randint(1, 12))  # Month
+    random_time.append(randint(1, 28))  # Date
+    random_time.append(randint(0, 23))  # Hour
+    random_time.append(randint(0, 59))  # Minute
+    random_time.append(randint(0, 59))  # Second
+    random_time.append(randint(0, 999))  # Millisecond
+    random_time.append(randint(0, 999))  # Microsecond
+    random_time.append(randint(0, 999))  # Nanosecond
+    x = CDFepoch.breakdown(CDFepoch.compute(random_time))
 
-        self.assertLessEqual(time_array[index[-1]], cdflib.cdfepoch.compute(test_end))
-        self.assertGreaterEqual(time_array[index[-1]+1], cdflib.cdfepoch.compute(test_end))
-        return
+    for i, t in enumerate(x):
+        assert t == random_time[i]
 
-    def test_findepochrange_cdfepoch16(self):
-        start_time = "1978-03-10T03:24:22.351793238462"
-        end_time = "1978-06-13T01:28:22.338327950466"
-        x = cdflib.cdfepoch.parse([start_time, end_time])
-        first_int_step = int((x[1].real - x[0].real) / 1000)
-        second_int_step = int((x[1].imag - x[0].imag) / 1000)
-        time_array = []
-        for i in range(0, 1000):
-            time_array.append(x[0]+complex(first_int_step*i, second_int_step*i))
 
-        test_start = [1978, 6, 10, 3, 24, 22, 351, 793, 238, 462]
-        test_end = [1978, 6, 12, 23, 11, 1, 338, 341, 416, 466]
-        index = cdflib.cdfepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
+def test_parse_CDFepoch():
+    x = CDFepoch.encode(62567898765432.0)
+    assert x == "1982-09-12T11:52:45.432"
 
-        # Test that the test_start is less than the first index, but more than one less
-        self.assertGreaterEqual(time_array[index[0]].real, cdflib.cdfepoch.compute(test_start).real)
-        self.assertLessEqual(time_array[index[0]-1].real, cdflib.cdfepoch.compute(test_start).real)
-        self.assertLessEqual(time_array[index[-1]].real, cdflib.cdfepoch.compute(test_end).real)
-        self.assertGreaterEqual(time_array[index[-1]+1].real, cdflib.cdfepoch.compute(test_end).real)
+    parsed = CDFepoch.parse(x)
+    assert parsed == approx(62567898765432.0)
+
+
+def test_parse_CDFepoch16():
+    input_time = np.complex(53467976543.0, 543218654100)
+    x = CDFepoch.encode(input_time)
+    assert x == "1694-05-01T07:42:23.543218654100"
+
+    parsed = CDFepoch.parse(x, to_np=True)
+    assert parsed == input_time
+
+
+def test_parse_cdftt2000():
+    input_time = 131415926535793238
+    x = CDFepoch.encode(input_time)
+    assert x == "2004-03-01T12:24:22.351793238"
+
+    parsed = CDFepoch.parse(x)
+    assert parsed == input_time
+
+
+def test_findepochrange_CDFepoch():
+    start_time = "2013-12-01T12:24:22.000"
+    end_time = "2014-12-01T12:24:22.000"
+    x = CDFepoch.parse([start_time, end_time])
+    time_array = np.arange(x[0], x[1], step=1000000)
+
+    test_start = [2014, 8, 1, 8, 1, 54, 123]
+    test_end = [2018, 1, 1, 1, 1, 1, 1]
+    index = CDFepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
+    # Test that the test_start is less than the first index, but more than one less
+    assert time_array[index[0]] >= CDFepoch.compute(test_start)
+    assert time_array[index[0]-1] <= CDFepoch.compute(test_start)
+
+    assert time_array[index[-1]] <= CDFepoch.compute(test_end)
+
+
+def test_findepochrange_cdftt2000():
+    start_time = "2004-03-01T12:24:22.351793238"
+    end_time = "2004-03-01T12:28:22.351793238"
+    x = CDFepoch.parse([start_time, end_time])
+    time_array = np.arange(x[0], x[1], step=1000000)
+
+    test_start = [2004, 3, 1, 12, 25, 54, 123, 111, 98]
+    test_end = [2004, 3, 1, 12, 26, 4, 123, 456, 789]
+    index = CDFepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
+    # Test that the test_start is less than the first index, but more than one less
+    assert time_array[index[0]] >= CDFepoch.compute(test_start)
+    assert time_array[index[0]-1] == approx(CDFepoch.compute(test_start))
+
+    assert time_array[index[-1]] <= CDFepoch.compute(test_end)
+    assert time_array[index[-1]+1] >= CDFepoch.compute(test_end)
+
+
+def test_findepochrange_CDFepoch16():
+    start_time = "1978-03-10T03:24:22.351793238462"
+    end_time = "1978-06-13T01:28:22.338327950466"
+    x = CDFepoch.parse([start_time, end_time])
+    first_int_step = int((x[1].real - x[0].real) / 1000)
+    second_int_step = int((x[1].imag - x[0].imag) / 1000)
+    time_array = []
+    for i in range(0, 1000):
+        time_array.append(x[0]+complex(first_int_step*i, second_int_step*i))
+
+    test_start = [1978, 6, 10, 3, 24, 22, 351, 793, 238, 462]
+    test_end = [1978, 6, 12, 23, 11, 1, 338, 341, 416, 466]
+    index = CDFepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
+
+    # Test that the test_start is less than the first index, but more than one less
+    assert time_array[index[0]].real >= CDFepoch.compute(test_start).real
+    assert time_array[index[0]-1].real <= CDFepoch.compute(test_start).real
+    assert time_array[index[-1]].real <= CDFepoch.compute(test_end).real
+    assert time_array[index[-1]+1].real >= CDFepoch.compute(test_end).real
 
 
 if __name__ == '__main__':
-    pytest.main(['-x', __file__])
+    pytest.main(['-xrsv', __file__])


### PR DESCRIPTION
* enable convenience reading of variables with like `h5py` etc.
  e.g.
  ```python
  import cdflib
  h = cdflib.CDF('myfile.cdf')
  dat = h['myvar']
  ```
  this is what new/most users will expect, and most will just use this to read data from a CDF file.
* Complete move to industry standard `pytest` framework
* Much more Python native exception raising--future test raises with Pytest
* speedup code with list comprehension

Now every `git push` is checked for PEP8 and static type hinting.