### PR TITLE
Expand user path when reading CDF

### DIFF
--- a/cdflib/__init__.py
+++ b/cdflib/__init__.py
@@ -7,6 +7,7 @@ from .epochs import CDFepoch as cdfepoch
 
 
 def CDF(path, cdf_spec=None, delete=False, validate=None):
+    path = os.path.expanduser(path)
     if (os.path.exists(path)):
         if delete:
             os.remove(path)


### PR DESCRIPTION
Currently, doing

```python
import cdflib
cdflib.CDF('~/sample.cdf')
```
won't read the file, because `os.path.exists()` isn't `True`; this just expands the path if there is a `~` in it, so the file is correctly read.