### PR TITLE
Ignore .eggs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build
 /.coverage
 doc/_build
 doc/api
+.eggs/*


### PR DESCRIPTION
This is just a directory with cached dependencies for `setuptools`