### PR TITLE
Numpy-like index on read

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 image:
 - Visual Studio 2017
-- Ubuntu
+- Ubuntu1804
 
 stack: python 3
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,20 @@
+[run]
+cover_pylib = false
+omit =
+  /home/travis/virtualenv/*
+  */site-packages/*
+  */bin/*
+
+[report]
+exclude_lines =
+  pragma: no cover
+  def __repr__
+  except RuntimeError
+  except NotImplementedError
+  except ImportError
+  except FileNotFoundError
+  except CalledProcessError
+  logging.warning
+  logging.error
+  logging.critical
+  if __name__ == .__main__.:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: required
 dist: xenial
 group: travis_latest
 
@@ -24,7 +23,7 @@ script:
 
 after_success:
 - if [[ $TRAVIS_PYTHON_VERSION == 3.6* ]]; then
-  pytest --cov --cov-config=setup.cfg;
+  pytest --cov
   coveralls;
   fi
 

--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -125,6 +125,9 @@ class CDF(object):
         if self.compressed_file is not None:
             self.compressed_file = None
 
+    def __getitem__(self, variable: str) -> np.ndarray:
+        return self.varget(variable)
+
     def close(self):
         pass
 

--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -1681,7 +1681,7 @@ class CDFepoch:
                     return -1.0E31
                 else:
                     if (len(value) == 24):
-                        date = re.findall('(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)', value)
+                        date = re.findall(r'(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)', value)
                         dd = int(date[0][0])
                         mm = CDFepoch._month_index(date[0][1])
                         yy = int(date[0][2])
@@ -1690,7 +1690,7 @@ class CDFepoch:
                         ss = int(date[0][5])
                         ms = int(date[0][6])
                     else:
-                        date = re.findall('(\d+)\-(\d+)\-(\d+)T(\d+)\:(\d+)\:(\d+)\.(\d+)',
+                        date = re.findall(r'(\d+)\-(\d+)\-(\d+)T(\d+)\:(\d+)\:(\d+)\.(\d+)',
                                           value)
                         yy = int(date[0][0])
                         mm = int(date[0][1])
@@ -1708,7 +1708,7 @@ class CDFepoch:
                     return -1.0E31-1.0E31j
                 else:
                     if (len(value) == 36):
-                        date = re.findall('(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)\.(\d+)\.(\d+)\.(\d+)',
+                        date = re.findall(r'(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)\.(\d+)\.(\d+)\.(\d+)',
                                           value)
                         dd = int(date[0][0])
                         mm = CDFepoch._month_index(date[0][1])
@@ -1721,7 +1721,7 @@ class CDFepoch:
                         ns = int(date[0][8])
                         ps = int(date[0][9])
                     else:
-                        date = re.findall('(\d+)\-(\d+)\-(\d+)T(\d+)\:(\d+)\:(\d+)\.(\d+)',
+                        date = re.findall(r'(\d+)\-(\d+)\-(\d+)T(\d+)\:(\d+)\:(\d+)\.(\d+)',
                                           value)
                         yy = int(date[0][0])
                         mm = int(date[0][1])
@@ -1749,7 +1749,7 @@ class CDFepoch:
                     return -9223372036854775807
                 else:
                     if (len(value) == 29):
-                        date = re.findall('(\d+)\-(\d+)\-(\d+)t(\d+)\:(\d+)\:(\d+)\.(\d+)',
+                        date = re.findall(r'(\d+)\-(\d+)\-(\d+)t(\d+)\:(\d+)\:(\d+)\.(\d+)',
                                           value)
                         yy = int(date[0][0])
                         mm = int(date[0][1])
@@ -1763,7 +1763,7 @@ class CDFepoch:
                         us = int(subms / 1000)
                         ns = int(subms % 1000)
                     else:
-                        date = re.findall('(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)\.(\d+)\.(\d+)',
+                        date = re.findall(r'(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)\.(\d+)\.(\d+)',
                                           value)
                         dd = int(date[0][0])
                         mm = CDFepoch._month_index(date[0][1])

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+
+minversion = 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
 
 [options.extras_require]
 tests =
-  pytest
+  pytest >= 3.9
   pytest-cov
   coveralls
   flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,23 +50,3 @@ console_scripts =
 max-line-length = 132
 exclude = .git,__pycache__,.eggs/,doc/,docs/,build/,dist/,archive/
 
-[coverage:run]
-cover_pylib = false
-omit =
-  /home/travis/virtualenv/*
-  */site-packages/*
-  */bin/*
-
-[coverage:report]
-exclude_lines =
-  pragma: no cover
-  def __repr__
-  except RuntimeError
-  except NotImplementedError
-  except ImportError
-  except FileNotFoundError
-  except CalledProcessError
-  logging.warning
-  logging.error
-  logging.critical
-  if __name__ == .__main__.:

--- a/tests/test_cdfwrite.py
+++ b/tests/test_cdfwrite.py
@@ -6,31 +6,28 @@ import pytest
 from pathlib import Path
 
 R = Path(__file__).parent
-fnbasic = R / "testfiles/testing.cdf"
-fncsum = R / "testfiles/testing_checksum.cdf"
-fncomp = R / "testfiles/testing_compression.cdf"
+fnbasic = 'testing.cdf'
 
 
-@pytest.fixture
-def cdf_create():
-    def _cdf_create(fn: Path, spec: dict):
-        return cdfwrite.CDF(fn, cdf_spec=spec, delete=True)
-    return _cdf_create
+def cdf_create(fn: Path, spec: dict):
+    return cdfwrite.CDF(fn, cdf_spec=spec)
 
 
-def test_cdf_creation(cdf_create):
-    cdf_create(fnbasic, {'rDim_sizes': [1]}).close()
+def test_cdf_creation(tmp_path):
+    fn = tmp_path / fnbasic
+    cdf_create(fn, {'rDim_sizes': [1]}).close()
 
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     info = reader.cdf_info()
     assert info['Majority'] == 'Column_major'
 
 
-def test_checksum(cdf_create):
+def test_checksum(tmp_path):
     # Setup the test_file
-    tfile = cdf_create(fncsum, {'Checksum': True})
+    fn = tmp_path / fnbasic
+    tfile = cdf_create(fn, {'Checksum': True})
 
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
@@ -48,14 +45,17 @@ def test_checksum(cdf_create):
     tfile.close()
 
 # %% Open the file to read
-    reader = cdfread.CDF(fncsum, validate=True)
+    reader = cdfread.CDF(fn, validate=True)
     # Test CDF info
     var = reader.varget("Variable1")
     assert (var == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).all()
+    # test convenience info
+    assert (reader["Variable1"] == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).all()
 
 
-def test_checksum_compressed(cdf_create):
+def test_checksum_compressed(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Data_Type'] = 2
@@ -68,13 +68,13 @@ def test_checksum_compressed(cdf_create):
 
     v = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
-    tfile = cdf_create(fncomp, {'Compressed': 6, 'Checksum': True})
+    tfile = cdf_create(fn, {'Compressed': 6, 'Checksum': True})
     tfile.write_var(var_spec, var_attrs=varatts,
                     var_data=v)
 
     tfile.close()
 # %% Open the file to read
-    reader = cdfread.CDF(fncomp, validate=True)
+    reader = cdfread.CDF(fn, validate=True)
 
     var = reader.varget("Variable1")
     assert (var == v).all()
@@ -86,8 +86,9 @@ def test_checksum_compressed(cdf_create):
     assert att['Data'] == '500'
 
 
-def test_file_compression(cdf_create):
+def test_file_compression(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
 
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
@@ -101,20 +102,22 @@ def test_file_compression(cdf_create):
 
     v = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
-    tfile = cdf_create(fncomp, {'Compressed': 6, 'Checksum': True})
+    tfile = cdf_create(fn, {'Compressed': 6, 'Checksum': True})
     tfile.write_var(var_spec, var_attrs=varatts,
                     var_data=v)
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fncomp)
+    reader = cdfread.CDF(fn)
     # Test CDF info
     var = reader.varget("Variable1")
     assert (var == v).all()
 
 
-def test_globalattrs(cdf_create):
+def test_globalattrs(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
+
     globalAttrs = {}
     globalAttrs['Global1'] = {0: 'Global Value 1'}
     globalAttrs['Global2'] = {0: 'Global Value 2'}
@@ -130,12 +133,12 @@ def test_globalattrs(cdf_create):
 
     globalAttrs['Global6'] = GA6
 
-    tfile = cdf_create(fncsum, {'Checksum': True})
+    tfile = cdf_create(fn, {'Checksum': True})
     tfile.write_globalattrs(globalAttrs)
 
     tfile.close()
 # %% Open the file to read
-    reader = cdfread.CDF(fncsum)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     attrib = reader.attinq('Global2')
@@ -151,8 +154,9 @@ def test_globalattrs(cdf_create):
         assert entry['Data'][x] == x
 
 
-def test_create_zvariable(cdf_create):
+def test_create_zvariable(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
     vs = {}
     vs['Variable'] = 'Variable1'
     vs['Data_Type'] = 1
@@ -161,12 +165,12 @@ def test_create_zvariable(cdf_create):
     vs['Dim_Sizes'] = []
     vs['Dim_Vary'] = True
 
-    tfile = cdf_create(fncsum, {'Checksum': True})
+    tfile = cdf_create(fn, {'Checksum': True})
     tfile.write_var(vs, var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
     tfile.close()
 
 # %% Open the file to read
-    reader = cdfread.CDF(fncsum)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")
@@ -176,8 +180,9 @@ def test_create_zvariable(cdf_create):
     assert (var == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).all()
 
 
-def test_create_rvariable(cdf_create):
+def test_create_rvariable(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
     vs = {}
     vs['Variable'] = 'Variable1'
     vs['Var_Type'] = 'rvariable'
@@ -187,12 +192,12 @@ def test_create_rvariable(cdf_create):
     vs['Dim_Sizes'] = []
     vs['Dim_Vary'] = [True]
 
-    tfile = cdf_create(fnbasic, {'rDim_sizes': [1]})
+    tfile = cdf_create(fn, {'rDim_sizes': [1]})
     tfile.write_var(vs, var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")
@@ -203,8 +208,10 @@ def test_create_rvariable(cdf_create):
         assert var[x] == x
 
 
-def test_create_zvariable_no_recvory(cdf_create):
-        # Setup the test_file
+def test_create_zvariable_no_recvory(tmp_path):
+    # Setup the test_file
+    fn = tmp_path / fnbasic
+
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Data_Type'] = 8
@@ -213,12 +220,12 @@ def test_create_zvariable_no_recvory(cdf_create):
     var_spec['Dim_Sizes'] = []
     var_spec['Dim_Vary'] = True
 
-    tfile = cdf_create(fnbasic, {'rDim_sizes': [1]})
+    tfile = cdf_create(fn, {'rDim_sizes': [1]})
     tfile.write_var(var_spec, var_data=np.array([2]))
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")
@@ -228,8 +235,10 @@ def test_create_zvariable_no_recvory(cdf_create):
     assert var == 2
 
 
-def test_create_zvariables_with_attributes(cdf_create):
+def test_create_zvariables_with_attributes(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
+
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Data_Type'] = 8
@@ -240,7 +249,7 @@ def test_create_zvariables_with_attributes(cdf_create):
     varatts['Attribute1'] = 1
     varatts['Attribute2'] = '500'
 
-    tfile = cdf_create(fnbasic, {'rDim_sizes': [1]})
+    tfile = cdf_create(fn, {'rDim_sizes': [1]})
     tfile.write_var(var_spec, var_attrs=varatts,
                     var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 
@@ -254,7 +263,7 @@ def test_create_zvariables_with_attributes(cdf_create):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     att = reader.attget("Attribute1", entry=0)
@@ -264,8 +273,10 @@ def test_create_zvariables_with_attributes(cdf_create):
     assert att['Data'] == '1000'
 
 
-def test_create_zvariables_then_attributes(cdf_create):
+def test_create_zvariables_then_attributes(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
+
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Data_Type'] = 8
@@ -273,7 +284,7 @@ def test_create_zvariables_then_attributes(cdf_create):
     var_spec['Rec_Vary'] = True
     var_spec['Dim_Sizes'] = []
 
-    tfile = cdf_create(fnbasic, {'rDim_sizes': [1]})
+    tfile = cdf_create(fn, {'rDim_sizes': [1]})
     tfile.write_var(var_spec, var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 
     var_spec['Variable'] = 'Variable2'
@@ -287,7 +298,7 @@ def test_create_zvariables_then_attributes(cdf_create):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     att = reader.attget("Attribute1", entry=0)
@@ -297,8 +308,10 @@ def test_create_zvariables_then_attributes(cdf_create):
     att['Data'] == '1000'
 
 
-def test_nonsparse_zvariable_blocking(cdf_create):
+def test_nonsparse_zvariable_blocking(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
+
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Data_Type'] = 8
@@ -308,20 +321,22 @@ def test_nonsparse_zvariable_blocking(cdf_create):
     var_spec['Block_Factor'] = 10000
     data = np.linspace(0, 999999, num=1000000)
 
-    tfile = cdf_create(fnbasic, {'rDim_sizes': [1]})
+    tfile = cdf_create(fn, {'rDim_sizes': [1]})
     tfile.write_var(var_spec, var_data=data)
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     var = reader.varget("Variable1")
     assert var[99999] == 99999
 
 
-def test_sparse_virtual_zvariable_blocking(cdf_create):
+def test_sparse_virtual_zvariable_blocking(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
+
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Data_Type'] = 8
@@ -341,12 +356,12 @@ def test_sparse_virtual_zvariable_blocking(cdf_create):
                                        physical_records4)).astype(int)
     sparse_data = [physical_records, data]
 
-    tfile = cdf_create(fnbasic, {'rDim_sizes': [1]})
+    tfile = cdf_create(fn, {'rDim_sizes': [1]})
     tfile.write_var(var_spec, var_data=sparse_data)
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     varinq = reader.varinq("Variable1")
@@ -357,8 +372,10 @@ def test_sparse_virtual_zvariable_blocking(cdf_create):
     assert var[70001] == 70001
 
 
-def test_sparse_zvariable_blocking(cdf_create):
+def test_sparse_zvariable_blocking(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
+
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Data_Type'] = 8
@@ -378,14 +395,15 @@ def test_sparse_zvariable_blocking(cdf_create):
                                        physical_records4)).astype(int)
     sparse_data = [physical_records, data]
 
-    tfile = cdf_create(fnbasic, {'rDim_sizes': [1]})
+    tfile = cdf_create(fn, {'rDim_sizes': [1]})
     tfile.write_var(var_spec, var_data=sparse_data)
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
-    # Test CDF infotfile = cdf_create(fnbasic, {'rDim_sizes': [1]})
+    # Test CDF info
+    # tfile = cdf_create(fn, {'rDim_sizes': [1]})
     varinq = reader.varinq("Variable1")
     var = reader.varget("Variable1")
     pad_num = varinq['Pad'][0]
@@ -394,8 +412,9 @@ def test_sparse_zvariable_blocking(cdf_create):
     assert var[70001] == 30000
 
 
-def test_sparse_zvariable_pad(cdf_create):
+def test_sparse_zvariable_pad(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Data_Type'] = 8
@@ -406,12 +425,12 @@ def test_sparse_zvariable_pad(cdf_create):
     data = [[200, 3000, 3100, 3500, 4000, 5000, 6000, 10000, 10001, 10002, 20000],
             np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])]
 
-    tfile = cdf_create(fnbasic, {'rDim_sizes': [1]})
+    tfile = cdf_create(fn, {'rDim_sizes': [1]})
     tfile.write_var(var_spec, var_data=data)
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     varinq = reader.varinq("Variable1")
@@ -422,8 +441,10 @@ def test_sparse_zvariable_pad(cdf_create):
     assert var[3000] == 1
 
 
-def test_sparse_zvariable_previous(cdf_create):
+def test_sparse_zvariable_previous(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
+
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Data_Type'] = 8
@@ -434,12 +455,12 @@ def test_sparse_zvariable_previous(cdf_create):
     data = [[200, 3000, 3100, 3500, 4000, 5000, 6000, 10000, 10001, 10002, 20000],
             np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])]
 
-    tfile = cdf_create(fnbasic, {'rDim_sizes': [1]})
+    tfile = cdf_create(fn, {'rDim_sizes': [1]})
     tfile.write_var(var_spec, var_data=data)
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     varinq = reader.varinq("Variable1")
@@ -450,8 +471,10 @@ def test_sparse_zvariable_previous(cdf_create):
     assert var[6001] == var[6000]
 
 
-def test_create_2d_rvariable(cdf_create):
+def test_create_2d_rvariable(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
+
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Var_Type'] = 'rvariable'
@@ -461,7 +484,7 @@ def test_create_2d_rvariable(cdf_create):
     var_spec['Dim_Sizes'] = []
     var_spec['Dim_Vary'] = [True, True]
 
-    tfile = cdf_create(fnbasic, {'rDim_sizes': [2, 2]})
+    tfile = cdf_create(fn, {'rDim_sizes': [2, 2]})
     tfile.write_var(var_spec, var_data=np.array([[[0, 1], [1, 2]],
                                                  [[2, 3], [3, 4]],
                                                  [[4, 5], [5, 6]],
@@ -470,7 +493,7 @@ def test_create_2d_rvariable(cdf_create):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")
@@ -484,8 +507,10 @@ def test_create_2d_rvariable(cdf_create):
         assert var[x][1][1] == 2*x+2
 
 
-def test_create_2d_rvariable_dimvary(cdf_create):
+def test_create_2d_rvariable_dimvary(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
+
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Var_Type'] = 'rvariable'
@@ -495,7 +520,7 @@ def test_create_2d_rvariable_dimvary(cdf_create):
     var_spec['Dim_Sizes'] = []
     var_spec['Dim_Vary'] = [True, False]
 
-    tfile = cdf_create(fnbasic,  {'rDim_sizes': [2, 20]})
+    tfile = cdf_create(fn,  {'rDim_sizes': [2, 20]})
 
     tfile.write_var(var_spec, var_data=np.array([[0, 1],
                                                  [2, 3],
@@ -506,7 +531,7 @@ def test_create_2d_rvariable_dimvary(cdf_create):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")
@@ -518,9 +543,10 @@ def test_create_2d_rvariable_dimvary(cdf_create):
         assert var[x][1] == 2*x+1
 
 
-def test_create_2d_r_and_z_variables(cdf_create):
-
+def test_create_2d_r_and_z_variables(tmp_path):
     # Setup the test_file
+    fn = tmp_path / fnbasic
+
     var_spec = {}
     var_spec['Variable'] = 'Variable1'
     var_spec['Var_Type'] = 'rvariable'
@@ -530,7 +556,7 @@ def test_create_2d_r_and_z_variables(cdf_create):
     var_spec['Dim_Sizes'] = []
     var_spec['Dim_Vary'] = [True, False]
 
-    tfile = cdf_create(fnbasic,  {'rDim_sizes': [2, 20]})
+    tfile = cdf_create(fn,  {'rDim_sizes': [2, 20]})
     tfile.write_var(var_spec, var_data=np.array([[0, 1],
                                                  [2, 3],
                                                  [4, 5],
@@ -547,7 +573,7 @@ def test_create_2d_r_and_z_variables(cdf_create):
 
     tfile.close()
     # Open the file to read
-    reader = cdfread.CDF(fnbasic)
+    reader = cdfread.CDF(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")

--- a/tests/test_cdfwrite.py
+++ b/tests/test_cdfwrite.py
@@ -10,14 +10,21 @@ fnbasic = 'testing.cdf'
 
 
 def cdf_create(fn: Path, spec: dict):
-    return cdfwrite.CDF(fn, cdf_spec=spec)
+    # str(fn) is a Python==3.5 workaround
+    return cdfwrite.CDF(str(fn), cdf_spec=spec)
+
+
+def cdf_read(fn: Path, validate: bool = False):
+    # str(fn) is a Python==3.5 workaround
+    return cdfread.CDF(str(fn), validate=validate)
 
 
 def test_cdf_creation(tmp_path):
+
     fn = tmp_path / fnbasic
     cdf_create(fn, {'rDim_sizes': [1]}).close()
 
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     info = reader.cdf_info()
@@ -45,7 +52,7 @@ def test_checksum(tmp_path):
     tfile.close()
 
 # %% Open the file to read
-    reader = cdfread.CDF(fn, validate=True)
+    reader = cdf_read(fn, validate=True)
     # Test CDF info
     var = reader.varget("Variable1")
     assert (var == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).all()
@@ -74,7 +81,7 @@ def test_checksum_compressed(tmp_path):
 
     tfile.close()
 # %% Open the file to read
-    reader = cdfread.CDF(fn, validate=True)
+    reader = cdf_read(fn, validate=True)
 
     var = reader.varget("Variable1")
     assert (var == v).all()
@@ -108,7 +115,7 @@ def test_file_compression(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
     # Test CDF info
     var = reader.varget("Variable1")
     assert (var == v).all()
@@ -138,7 +145,7 @@ def test_globalattrs(tmp_path):
 
     tfile.close()
 # %% Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     attrib = reader.attinq('Global2')
@@ -170,7 +177,7 @@ def test_create_zvariable(tmp_path):
     tfile.close()
 
 # %% Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")
@@ -197,7 +204,7 @@ def test_create_rvariable(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")
@@ -225,7 +232,7 @@ def test_create_zvariable_no_recvory(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")
@@ -263,7 +270,7 @@ def test_create_zvariables_with_attributes(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     att = reader.attget("Attribute1", entry=0)
@@ -298,7 +305,7 @@ def test_create_zvariables_then_attributes(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     att = reader.attget("Attribute1", entry=0)
@@ -326,7 +333,7 @@ def test_nonsparse_zvariable_blocking(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     var = reader.varget("Variable1")
@@ -361,7 +368,7 @@ def test_sparse_virtual_zvariable_blocking(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     varinq = reader.varinq("Variable1")
@@ -400,7 +407,7 @@ def test_sparse_zvariable_blocking(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     # tfile = cdf_create(fn, {'rDim_sizes': [1]})
@@ -430,7 +437,7 @@ def test_sparse_zvariable_pad(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     varinq = reader.varinq("Variable1")
@@ -460,7 +467,7 @@ def test_sparse_zvariable_previous(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     varinq = reader.varinq("Variable1")
@@ -493,7 +500,7 @@ def test_create_2d_rvariable(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")
@@ -531,7 +538,7 @@ def test_create_2d_rvariable_dimvary(tmp_path):
     tfile.close()
 
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")
@@ -573,7 +580,7 @@ def test_create_2d_r_and_z_variables(tmp_path):
 
     tfile.close()
     # Open the file to read
-    reader = cdfread.CDF(fn)
+    reader = cdf_read(fn)
 
     # Test CDF info
     varinfo = reader.varinq("Variable1")


### PR DESCRIPTION
other major libraries like NetCDF4 and h5py use simple numpy-like read indexing like:
```python
with h5py.File('my.h5') as f:
  x = f["x"]
```

this PR bring that easy indexing users expect to cdflib:
```python
h = cdfread.CDF('my.cdf')
x = h["x"]
```

That is done by the `__getitem__` in cdfread.py

Separately, I cleaned up:
* read/write functions in tests/test_cdfwrite.py, allowing backward compatibility to Python 3.5, and which would be required as well for Python 2.7 if that is implemented someday.
* corrected raw-string for regex, which is needed for Python &ge; 3.7

I have been having to run my own fork of CDFlib, and these changes would allow me to direct my users to this main CDFlib instead. thanks.

As we discussed at AGU,  I have made other performance and API improvements, but I'll do those in future PRs rather than one enormous PR.