### PR TITLE
datetime.datetime output, raise Error instead of return None

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 132
+exclude = .git,__pycache__,.eggs/,doc/,docs/,build/,dist/,archive/

--- a/cdflib/__init__.py
+++ b/cdflib/__init__.py
@@ -1,7 +1,7 @@
 import os
 from . import cdfread
 from . import cdfwrite
-from .epochs import CDFepoch as cdfepoch
+from .epochs import CDFepoch as cdfepoch  # noqa: F401
 
 # This function determines if we are reading or writing a file
 

--- a/cdflib/__init__.py
+++ b/cdflib/__init__.py
@@ -1,16 +1,16 @@
-import os
 from . import cdfread
 from . import cdfwrite
 from .epochs import CDFepoch as cdfepoch  # noqa: F401
-
+from pathlib import Path
 # This function determines if we are reading or writing a file
 
 
 def CDF(path, cdf_spec=None, delete=False, validate=None):
-    path = os.path.expanduser(path)
-    if (os.path.exists(path)):
+    path = Path(path).expanduser()
+
+    if path.is_file():
         if delete:
-            os.remove(path)
+            path.unlink()
             return
         else:
             return cdfread.CDF(path, validate=validate)

--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -28,7 +28,7 @@ Sample use::
 
 @author: Bryan Harter, Michael Liu
 '''
-import pathlib
+from pathlib import Path
 import tempfile
 import numpy as np
 import sys
@@ -54,7 +54,7 @@ class CDF:
 
     def __init__(self, path, validate=None):
 
-        path = pathlib.Path(path).expanduser()
+        path = Path(path).expanduser()
         if not path.is_file():
             path = path.with_suffix('.cdf')
             if not path.is_file():
@@ -153,13 +153,13 @@ class CDF:
                 +---------------+--------------------------------------------------------------------------------+
                 | ['Checksum']  | the checksum indicator                                                         |
                 +---------------+--------------------------------------------------------------------------------+
-                | ['Num_rdim']  | the number of dimensions, applicable only to rVariables                        |
+                | ['Num_rdim']  | the number of dimensions, applicable only to rVariables
                 +---------------+--------------------------------------------------------------------------------+
-                | ['rDim_sizes'] | the dimensional sizes, applicable only to rVariables                          |
-                +----------------+-------------------------------------------------------------------------------+
-                | ['Compressed']| CDF is compressed at the file-level                                            |
+                | ['rDim_sizes'] | the dimensional sizes, applicable only to rVariables
+                +----------------+--------------------------------------------------------------------------------+
+                | ['Compressed']| CDF is compressed at the file-level
                 +---------------+--------------------------------------------------------------------------------+
-                | ['LeapSecondUpdated']| The last updated for the leap second table, if applicable               |
+                | ['LeapSecondUpdated']| The last updated for the leap second table, if applicable
                 +---------------+--------------------------------------------------------------------------------+
 
         """
@@ -563,7 +563,7 @@ class CDF:
         """
         byte_loc = self._first_adr
         return_dict = {}
-        for _ in range(0, self._num_att):
+        for _ in range(self._num_att):
             adr_info = self._read_adr(byte_loc)
 
             if (adr_info['scope'] != 1):
@@ -579,7 +579,7 @@ class CDF:
             else:
                 entries = {}
             aedr_byte_loc = adr_info['first_gr_entry']
-            for _ in range(0, adr_info['num_gr_entry']):
+            for _ in range(adr_info['num_gr_entry']):
                 if (self.cdfversion == 3):
                     aedr_info = self._read_aedr(aedr_byte_loc, to_np=to_np)
                 else:
@@ -694,7 +694,7 @@ class CDF:
             f.seek(data_start)
             decompressed_data = gzip.decompress(f.read(data_size))
 
-        newpath = pathlib.Path(tempfile.NamedTemporaryFile(suffix='.cdf').name)
+        newpath = Path(tempfile.NamedTemporaryFile(suffix='.cdf').name)
         with newpath.open('wb') as g:
             g.write(bytearray.fromhex('cdf30001'))
             g.write(bytearray.fromhex('0000ffff'))

--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -176,16 +176,22 @@ class CDFepoch:
 def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[datetime.datetime]:
         """
         Encodes the epoch(s) into Python datetime.  Precision is only
-        kept to the nearest microsecond for Python < 3.7.
+        kept to the nearest microsecond.
+
+        Possible len() from breakdown for each time are in range 6..9
 
         If to_np is True, then the values will be returned in a numpy array.
         """
         time_list = self.breakdown(cdf_time, to_np=False)
+        if isinstance(time_list[0], int):  # single time
+            time_list = [time_list]
 
-        if len(time_list[0]) == 8:
+        if len(time_list[0]) >= 8:
             dt = [datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], microsecond=t[6]*1000+t[7]) for t in time_list]
         elif len(time_list[0]) == 7:
             dt = [datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], microsecond=t[6]*1000) for t in time_list]
+        elif len(time_list[0]) == 6:
+            dt = [datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5]) for t in time_list]
         else:
             raise ValueError('unknown cdf_time format')
 

--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -36,7 +36,7 @@ import math
 import re
 import numbers
 import os
-from typing import Sequence, List
+from typing import Sequence, List, Union
 import datetime
 
 LEAPSEC_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -124,25 +124,22 @@ class CDFepoch:
                 Or, if iso_8601 is set to False,
                 02-Feb-2008 06:08:10.012.014.016
         """
-        if (isinstance(epochs, int) or isinstance(epochs, np.int64)):
+        if isinstance(epochs, (int, np.int64)):
             return CDFepoch.encode_tt2000(epochs, iso_8601)
-        elif (isinstance(epochs, float) or isinstance(epochs, np.float64)):
+        elif isinstance(epochs, (float, np.float64)):
             return CDFepoch.encode_epoch(epochs, iso_8601)
-        elif (isinstance(epochs, complex) or isinstance(epochs, np.complex128)):
+        elif isinstance(epochs, (complex, np.complex128)):
             return CDFepoch.encode_epoch16(epochs, iso_8601)
-        elif (isinstance(epochs, list) or isinstance(epochs, np.ndarray)):
-            if (isinstance(epochs[0], int) or isinstance(epochs[0], np.int64)):
+        elif isinstance(epochs, (list, np.ndarray)):
+            if isinstance(epochs[0], (int, np.int64)):
                 return CDFepoch.encode_tt2000(epochs, iso_8601)
-            elif (isinstance(epochs[0], float) or
-                  isinstance(epochs[0], np.float64)):
+            elif isinstance(epochs[0], (float, np.float64)):
                 return CDFepoch.encode_epoch(epochs, iso_8601)
-            elif (isinstance(epochs[0], complex) or
-                  isinstance(epochs[0], np.complex128)):
+            elif isinstance(epochs[0], (complex, np.complex128)):
                 return CDFepoch.encode_epoch16(epochs, iso_8601)
-            else:
-                raise ValueError('Bad input')
-        else:
-            raise ValueError('Bad input')
+
+        raise TypeError('Not sure how to handle type {}'.format(type(epochs)))
+
 
     @staticmethod
     def breakdown(epochs, to_np: bool = False):
@@ -162,18 +159,12 @@ class CDFepoch:
                 return CDFepoch.breakdown_epoch(epochs, to_np)
             elif isinstance(epochs[0], (complex, np.complex128)):
                 return CDFepoch.breakdown_epoch16(epochs, to_np)
-<<<<<<< HEAD
-            else:
-                raise ValueError('Bad input')
-        else:
-            raise ValueError('Bad input')
-=======
 
         raise TypeError('Not sure how to handle type {}'.format(type(epochs)))
->>>>>>> correct logic
 
 
-def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[datetime.datetime]:
+    def to_datetime(self, cdf_time: Union[int, Sequence[int]],
+                    to_np: bool = False) -> List[datetime.datetime]:
         """
         Encodes the epoch(s) into Python datetime.  Precision is only
         kept to the nearest microsecond.
@@ -183,7 +174,7 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
         If to_np is True, then the values will be returned in a numpy array.
         """
         time_list = self.breakdown(cdf_time, to_np=False)
-        if isinstance(time_list[0], int):  # single time
+        if isinstance(time_list[0], (float, int, complex)):  # single time
             time_list = [time_list]
 
         if len(time_list[0]) >= 8:
@@ -274,7 +265,7 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
         elif isinstance(datetimes[0], (list, tuple, np.ndarray)):
             items = len(datetimes[0])
         else:
-            raise ValueError('Unknown input')
+            raise TypeError('Not sure how to handle type {}'.format(type(datetimes)))
 
         if (items == 7):
             return CDFepoch.compute_epoch(datetimes, to_np)
@@ -283,7 +274,8 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
         elif (items == 9):
             return CDFepoch.compute_tt2000(datetimes, to_np)
         else:
-            raise ValueError('Unknown input')
+            raise TypeError('Unknown input')
+
 
     def findepochrange(epochs, starttime=None, endtime=None):  # @NoSelf
         """
@@ -315,41 +307,30 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             elif (isinstance(epochs[0], complex) or
                   isinstance(epochs[0], np.complex128)):
                 return CDFepoch.epochrange_epoch16(epochs, starttime, endtime)
-<<<<<<< HEAD
-            else:
-                raise ValueError('Bad input')
-        else:
-            raise ValueError('Bad input')
-=======
 
         raise TypeError('Bad input')
 
->>>>>>> correct logic
 
-    def encode_tt2000(tt2000, iso_8601=None):  # @NoSelf
+    def encode_tt2000(tt2000, iso_8601: bool = True):  # @NoSelf
 
         if (isinstance(tt2000, int) or isinstance(tt2000, np.int64)):
             new_tt2000 = [tt2000]
         elif (isinstance(tt2000, list) or isinstance(tt2000, np.ndarray)):
             new_tt2000 = tt2000
         else:
-<<<<<<< HEAD
-            raise ValueError('Bad input')
-=======
             raise TypeError('Bad input')
 
->>>>>>> correct logic
         count = len(new_tt2000)
         encodeds = []
-        for x in range(0, count):
+        for x in range(count):
             nanoSecSinceJ2000 = new_tt2000[x]
             if (nanoSecSinceJ2000 == CDFepoch.FILLED_TT2000_VALUE):
-                if (iso_8601 == None or iso_8601 != False):
+                if iso_8601:
                     return '9999-12-31T23:59:59.999999999'
                 else:
                     return '31-Dec-9999 23:59:59.999.999.999'
             if (nanoSecSinceJ2000 == CDFepoch.DEFAULT_TT2000_PADVALUE):
-                if (iso_8601 == None or iso_8601 != False):
+                if iso_8601:
                     return '0000-01-01T00:00:00.000000000'
                 else:
                     return '01-Jan-0000 00:00:00.000.000.000'
@@ -363,7 +344,7 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             ll = datetime[6]
             lu = datetime[7]
             la = datetime[8]
-            if (iso_8601 == None or iso_8601 != False):
+            if iso_8601:
                 # yyyy-mm-ddThh:mm:ss.mmmuuunnn
                 encoded = str(ly).zfill(4)
                 encoded += '-'
@@ -400,7 +381,7 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                 encoded += '.'
                 encoded += str(la).zfill(3)
 
-            if (count == 1):
+            if count == 1:
                 return encoded
             else:
                 encodeds.append(encoded)
@@ -430,12 +411,8 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
         elif isinstance(tt2000, (list, tuple, np.ndarray)):
             new_tt2000 = tt2000
         else:
-<<<<<<< HEAD
-            raise ValueError('Bad input data')
-=======
             raise TypeError('unsure how to handle {}'.format(type(tt2000)))
 
->>>>>>> correct logic
         count = len(new_tt2000)
         toutcs = []
         for x in range(count):
@@ -565,16 +542,10 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
     @staticmethod
     def compute_tt2000(datetimes, to_np: bool = False):
 
-<<<<<<< HEAD
-        if (not isinstance(datetimes, list) and not isinstance(datetimes, tuple)):
-            raise ValueError('datetime must be in list form')
-        if (isinstance(datetimes[0], numbers.Number)):
-=======
         if not isinstance(datetimes, (list, tuple)):
             raise TypeError('datetime must be in list form')
 
         if isinstance(datetimes[0], numbers.Number):
->>>>>>> correct logic
             new_datetimes = [datetimes]
             count = 1
         else:
@@ -666,10 +637,7 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                 nsec = int(1000.0 * (xxx - usec))
             else:
                 raise ValueError('Invalid tt2000 components')
-<<<<<<< HEAD
-=======
 
->>>>>>> correct logic
             if (month == 0):
                 month = 1
             if (year == 9999 and month == 12 and day == 31 and hour == 23 and
@@ -835,19 +803,19 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             new_epochs = epochs
         return np.where(np.logical_and(new_epochs >= stime, new_epochs <= etime))[0]
 
-    def encode_epoch16(epochs, iso_8601=True):  # @NoSelf
+    @staticmethod
+    def encode_epoch16(epochs, iso_8601: bool = True):
 
-        if (isinstance(epochs, complex) or
-                isinstance(epochs, np.complex128)):
+        if isinstance(epochs, (complex, np.complex128)):
             new_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
+        elif isinstance(epochs, (list, tuple, np.ndarray)):
             new_epochs = epochs
         else:
-            raise ValueError('Bad data')
+            raise TypeError('bad data')
+
         count = len(new_epochs)
         encodeds = []
-        for x in range(0, count):
+        for x in range(count):
             # complex
             if ((new_epochs[x].real == -1.0E31) and (new_epochs[x].imag == -1.0E31)):
                 if iso_8601:
@@ -856,13 +824,14 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                     encoded = '31-Dec-9999 23:59:59.999.999.999.999'
             else:
                 encoded = CDFepoch._encodex_epoch16(new_epochs[x], iso_8601)
-            if (count == 1):
+            if count == 1:
                 return encoded
             else:
                 encodeds.append(encoded)
         return encodeds
 
-    def _encodex_epoch16(epoch16, iso_8601=True):  # @NoSelf
+    @staticmethod
+    def _encodex_epoch16(epoch16, iso_8601: bool = True) -> str:
 
         components = CDFepoch.breakdown_epoch16(epoch16)
         if iso_8601:
@@ -917,18 +886,10 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
     @staticmethod
     def compute_epoch16(datetimes, to_np: bool = False):
 
-<<<<<<< HEAD
-        if (not isinstance(datetimes, list) and
-                not isinstance(datetimes, tuple)):
-            raise ValueError('Bad input')
-        if (not isinstance(datetimes[0], list) and
-                not isinstance(datetimes[0], tuple)):
-=======
         if not isinstance(datetimes, (list, tuple)):
             raise TypeError('Bad input')
 
         if not isinstance(datetimes[0], (list, tuple)):
->>>>>>> correct logic
             new_dates = []
             new_dates = [datetimes]
         else:
@@ -1046,15 +1007,10 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                 psec = int(1000.0 * (xxx - nsec))
             else:
                 raise ValueError('Invalid epoch16 components')
-<<<<<<< HEAD
-            if (year < 0):
-                raise ValueError('Illegal epoch field')
-=======
 
             if (year < 0):
                 raise ValueError('Illegal epoch field')
 
->>>>>>> correct logic
             if (year == 9999 and month == 12 and day == 31 and hour == 23 and
                 minute == 59 and second == 59 and msec == 999 and
                     usec == 999 and nsec == 999 and psec == 999):
@@ -1109,13 +1065,8 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
         elif isinstance(epochs, (list, tuple, np.ndarray)):
             new_epochs = epochs
         else:
-<<<<<<< HEAD
-            raise ValueError('Bad data')
-            return
-=======
             raise TypeError('Bad data')
 
->>>>>>> correct logic
         count = len(new_epochs)
         components = []
         for x in range(0, count):
@@ -1316,14 +1267,16 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             indx.append(int(count/2)-1)
         return np.arange(indx[0], indx[1]+1, step=1)
 
-    def encode_epoch(epochs, iso_8601=True):  # @NoSelf
+    @staticmethod
+    def encode_epoch(epochs, iso_8601: bool = True):  # @NoSelf
 
-        if (isinstance(epochs, float) or isinstance(epochs, np.float64)):
+        if isinstance(epochs, (float, np.float64)):
             new_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, np.ndarray)):
+        elif isinstance(epochs, (list, np.ndarray)):
             new_epochs = epochs
         else:
-            raise ValueError('Bad data')
+            raise TypeError('Bad data')
+
         count = len(new_epochs)
         encodeds = []
         for x in range(0, count):
@@ -1340,7 +1293,8 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             encodeds.append(encoded)
         return encodeds
 
-    def _encodex_epoch(epoch, iso_8601=None):  # @NoSelf
+    @staticmethod
+    def _encodex_epoch(epoch, iso_8601: bool = True):  # @NoSelf
 
         components = CDFepoch.breakdown_epoch(epoch)
         if (iso_8601):
@@ -1626,18 +1580,16 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
 
         Specify to_np to True, if the result should be in numpy class.
         """
-        if ((isinstance(value, list) or isinstance(value, tuple)) and
-                not (isinstance(value[0], str))):
-            raise ValueError('Invalid value... should be a string or a list of string')
-        elif ((not (isinstance(value, list))) and
-              (not (isinstance(value, tuple))) and
-              (not (isinstance(value, str)))):
-            raise ValueError('Invalid value... should be a string or a list of string')
+        if isinstance(value, (list, tuple)) and not isinstance(value[0], str):
+            raise TypeError('should be a string or a list of string')
+
+        elif not isinstance(value, (list, tuple, str)):
+            raise TypeError('Invalid value... should be a string or a list of string')
         else:
-            if (isinstance(value, list) or isinstance(value, tuple)):
+            if isinstance(value, (list, tuple)):
                 num = len(value)
                 epochs = []
-                for x in range(0, num):
+                for x in range(num):
                     epochs.append(CDFepoch._parse_epoch(value[x]))
                 if not to_np:
                     return epochs
@@ -1650,19 +1602,19 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                     return np.array(CDFepoch._parse_epoch(value))
 
     def _parse_epoch(value):  # @NoSelf
-        if (isinstance(value, list) or isinstance(value, tuple)):
+        if isinstance(value, (list, tuple)):
             epochs = []
             for x in range(0, len(value)):
                 epochs.append(value[x])
             return epochs
         else:
-            if (len(value) == 23 or len(value) == 24):
+            if len(value) in (23, 24):
                 # CDF_EPOCH
-                if (value.lower() == '31-dec-9999 23:59:59.999' or
-                        value.lower() == '9999-12-31t23:59:59.999'):
+                if value.lower() in ('31-dec-9999 23:59:59.999',
+                                     '9999-12-31t23:59:59.999'):
                     return -1.0E31
                 else:
-                    if (len(value) == 24):
+                    if len(value) == 24:
                         date = re.findall(r'(\d+)\-(.+)\-(\d+) (\d+)\:(\d+)\:(\d+)\.(\d+)', value)
                         dd = int(date[0][0])
                         mm = CDFepoch._month_index(date[0][1])
@@ -1682,11 +1634,11 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                         ss = int(date[0][5])
                         ms = int(date[0][6])
                     return CDFepoch.compute_epoch([yy, mm, dd, hh, mn, ss, ms])
-            elif (len(value) == 36 or (len(value) == 32 and
-                                       value[10].lower() == 't')):
+            elif len(value) == 36 or (len(value) == 32 and
+                                       value[10].lower() == 't'):
                 # CDF_EPOCH16
-                if (value.lower() == '31-dec-9999 23:59:59.999.999.999.999' or
-                        value.lower() == '9999-12-31t23:59:59.999999999999'):
+                if value.lower() in ('31-dec-9999 23:59:59.999.999.999.999',
+                                      '9999-12-31t23:59:59.999999999999'):
                     return -1.0E31-1.0E31j
                 else:
                     if (len(value) == 36):

--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -36,6 +36,8 @@ import math
 import re
 import numbers
 import os
+from typing import Sequence, List
+import datetime
 
 LEAPSEC_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                             'CDFLeapSeconds.txt')
@@ -166,6 +168,26 @@ class CDFepoch:
                 raise ValueError('Bad input')
         else:
             raise ValueError('Bad input')
+
+
+def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[datetime.datetime]:
+        """
+        Encodes the epoch(s) into Python datetime.  Precision is only
+        kept to the nearest microsecond for Python < 3.7.
+
+        If to_np is True, then the values will be returned in a numpy array.
+        """
+        time_list = breakdown(cdf_time, to_np=False)
+
+        if len(time_list[0]) == 8:
+            dt = [datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], microsecond=t[6]*1000+t[7]) for t in time_list]
+        elif len(time_list[0]) == 7:
+            dt = [datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], microsecond=t[6]*1000) for t in time_list]
+        else:
+            raise ValueError('unknown cdf_time format')
+
+        return np.array(dt) if to_np else dt
+
 
     def unixtime(cdf_time, to_np=False):  # @NoSelf
         """

--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -98,7 +98,8 @@ class CDFepoch:
     currentJDay = -1
     currentLeapSeconds = -1
 
-    def encode(epochs, iso_8601=True):  # @NoSelf
+    @staticmethod
+    def encode(epochs, iso_8601: bool = True):  # @NoSelf
         """
         Encodes the epoch(s) into UTC string(s).
 
@@ -1517,40 +1518,39 @@ class CDFepoch:
     @staticmethod
     def epochrange_epoch(epochs, starttime=None, endtime=None):  # @NoSelf
 
-        if (isinstance(epochs, float) or isinstance(epochs, np.float64)):
+        if isinstance(epochs, (float, np.float64)):
             new2_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
-            if (isinstance(epochs[0], float) or
-                    isinstance(epochs[0], np.float64)):
+        elif isinstance(epochs, (list, tuple, np.ndarray)):
+            if isinstance(epochs[0], (float, np.float64)):
                 new2_epochs = epochs
             else:
-                raise ValueError('Bad data')
+                raise TypeError('Bad data')
         else:
-            raise ValueError('Bad data')
-        if (starttime == None):
+            raise TypeError('Bad data')
+
+        if (starttime is None):
             stime = 0.0
         else:
-            if (isinstance(starttime, float) or isinstance(starttime, int) or
-                    isinstance(starttime, np.float64)):
+            if isinstance(starttime, (float, int, np.float64)):
                 stime = starttime
-            elif (isinstance(starttime, list) or isinstance(starttime, tuple)):
+            elif isinstance(starttime, (list, tuple)):
                 stime = CDFepoch.compute_epoch(starttime)
             else:
-                raise ValueError('Bad start time')
-        if (endtime != None):
-            if (isinstance(endtime, float) or isinstance(endtime, int) or
-                    isinstance(endtime, np.float64)):
+                raise TypeError('Bad start time')
+
+        if (endtime is not None):
+            if isinstance(endtime, (float, int, np.float64)):
                 etime = endtime
-            elif (isinstance(endtime, list) or isinstance(endtime, tuple)):
+            elif isinstance(endtime, (list, tuple)):
                 etime = CDFepoch.compute_epoch(endtime)
             else:
-                raise ValueError('Bad end time')
+                raise TypeError('Bad end time')
         else:
             etime = 1.0E31
         if (stime > etime):
             raise ValueError('Invalid start/end time')
-        if (isinstance(epochs, list) or isinstance(epochs, tuple)):
+
+        if isinstance(epochs, (list, tuple)):
             new_epochs = np.array(epochs)
         else:
             new_epochs = epochs

--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -144,30 +144,33 @@ class CDFepoch:
         else:
             raise ValueError('Bad input')
 
-    def breakdown(epochs, to_np=None):  # @NoSelf
+    @staticmethod
+    def breakdown(epochs, to_np: bool = False):
 
         #Returns either a single array, or a array of arrays depending on the input
 
-        if (isinstance(epochs, int) or isinstance(epochs, np.int64)):
+        if isinstance(epochs, (int, np.int64)):
             return CDFepoch.breakdown_tt2000(epochs, to_np)
-        elif (isinstance(epochs, float) or isinstance(epochs, np.float64)):
+        elif isinstance(epochs, (float, np.float64)):
             return CDFepoch.breakdown_epoch(epochs, to_np)
-        elif (isinstance(epochs, complex) or isinstance(epochs, np.complex128)):
+        elif isinstance(epochs, (complex, np.complex128)):
             return CDFepoch.breakdown_epoch16(epochs, to_np)
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
-            if (isinstance(epochs[0], int) or isinstance(epochs[0], np.int64)):
+        elif isinstance(epochs, (list, tuple, np.ndarray)):
+            if isinstance(epochs[0], (int, np.int64)):
                 return CDFepoch.breakdown_tt2000(epochs, to_np)
-            elif (isinstance(epochs[0], float) or
-                  isinstance(epochs[0], np.float64)):
+            elif isinstance(epochs[0], (float, np.float64)):
                 return CDFepoch.breakdown_epoch(epochs, to_np)
-            elif (isinstance(epochs[0], complex) or
-                  isinstance(epochs[0], np.complex128)):
+            elif isinstance(epochs[0], (complex, np.complex128)):
                 return CDFepoch.breakdown_epoch16(epochs, to_np)
+<<<<<<< HEAD
             else:
                 raise ValueError('Bad input')
         else:
             raise ValueError('Bad input')
+=======
+
+        raise TypeError('Not sure how to handle type {}'.format(type(epochs)))
+>>>>>>> correct logic
 
 
 def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[datetime.datetime]:
@@ -177,7 +180,7 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
 
         If to_np is True, then the values will be returned in a numpy array.
         """
-        time_list = breakdown(cdf_time, to_np=False)
+        time_list = self.breakdown(cdf_time, to_np=False)
 
         if len(time_list[0]) == 8:
             dt = [datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], microsecond=t[6]*1000+t[7]) for t in time_list]
@@ -188,8 +191,8 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
 
         return np.array(dt) if to_np else dt
 
-
-    def unixtime(cdf_time, to_np=False):  # @NoSelf
+    @staticmethod
+    def unixtime(cdf_time, to_np: bool = False):  # @NoSelf
         """
         Encodes the epoch(s) into seconds after 1970-01-01.  Precision is only
         kept to the nearest microsecond.
@@ -222,7 +225,8 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             unixtime.append(datetime.datetime(*date).replace(tzinfo=datetime.timezone.utc).timestamp())
         return np.array(unixtime) if to_np else unixtime
 
-    def compute(datetimes, to_np=None):  # @NoSelf
+    @staticmethod
+    def compute(datetimes, to_np: bool = False):  # @NoSelf
         """
         Computes the provided date/time components into CDF epoch value(s).
 
@@ -305,10 +309,16 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             elif (isinstance(epochs[0], complex) or
                   isinstance(epochs[0], np.complex128)):
                 return CDFepoch.epochrange_epoch16(epochs, starttime, endtime)
+<<<<<<< HEAD
             else:
                 raise ValueError('Bad input')
         else:
             raise ValueError('Bad input')
+=======
+
+        raise TypeError('Bad input')
+
+>>>>>>> correct logic
 
     def encode_tt2000(tt2000, iso_8601=None):  # @NoSelf
 
@@ -317,7 +327,12 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
         elif (isinstance(tt2000, list) or isinstance(tt2000, np.ndarray)):
             new_tt2000 = tt2000
         else:
+<<<<<<< HEAD
             raise ValueError('Bad input')
+=======
+            raise TypeError('Bad input')
+
+>>>>>>> correct logic
         count = len(new_tt2000)
         encodeds = []
         for x in range(0, count):
@@ -385,7 +400,8 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                 encodeds.append(encoded)
         return encodeds
 
-    def breakdown_tt2000(tt2000, to_np=None):  # @NoSelf
+    @staticmethod
+    def breakdown_tt2000(tt2000, to_np: bool = False):
         """
         Breaks down the epoch(s) into UTC components.
 
@@ -403,16 +419,20 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
 
         Specify to_np to True, if the result should be in numpy array.
         """
-        if (isinstance(tt2000, int) or isinstance(tt2000, np.int64)):
+        if isinstance(tt2000, (int, np.int64)):
             new_tt2000 = [tt2000]
-        elif (isinstance(tt2000, list) or isinstance(tt2000, tuple) or
-              isinstance(tt2000, np.ndarray)):
+        elif isinstance(tt2000, (list, tuple, np.ndarray)):
             new_tt2000 = tt2000
         else:
+<<<<<<< HEAD
             raise ValueError('Bad input data')
+=======
+            raise TypeError('unsure how to handle {}'.format(type(tt2000)))
+
+>>>>>>> correct logic
         count = len(new_tt2000)
         toutcs = []
-        for x in range(0, count):
+        for x in range(count):
             nanoSecSinceJ2000 = new_tt2000[x]
             toPlus = 0.0
             t3 = nanoSecSinceJ2000
@@ -524,30 +544,38 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             datetime.append(ml1)
             datetime.append(ma1)
             datetime.append(na1)
-            if (count == 1):
-                if (to_np == None):
+            if count == 1:
+                if not to_np:
                     return datetime
                 else:
                     return np.array(datetime)
             else:
                 toutcs.append(datetime)
-        if (to_np == None):
+        if not to_np:
             return toutcs
         else:
             return np.array(toutcs)
 
-    def compute_tt2000(datetimes, to_np=None):  # @NoSelf
+    @staticmethod
+    def compute_tt2000(datetimes, to_np: bool = False):
 
+<<<<<<< HEAD
         if (not isinstance(datetimes, list) and not isinstance(datetimes, tuple)):
             raise ValueError('datetime must be in list form')
         if (isinstance(datetimes[0], numbers.Number)):
+=======
+        if not isinstance(datetimes, (list, tuple)):
+            raise TypeError('datetime must be in list form')
+
+        if isinstance(datetimes[0], numbers.Number):
+>>>>>>> correct logic
             new_datetimes = [datetimes]
             count = 1
         else:
             count = len(datetimes)
             new_datetimes = datetimes
         nanoSecSinceJ2000s = []
-        for x in range(0, count):
+        for x in range(count):
             datetime = new_datetimes[x]
             year = int(datetime[0])
             month = int(datetime[1])
@@ -632,6 +660,10 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                 nsec = int(1000.0 * (xxx - usec))
             else:
                 raise ValueError('Invalid tt2000 components')
+<<<<<<< HEAD
+=======
+
+>>>>>>> correct logic
             if (month == 0):
                 month = 1
             if (year == 9999 and month == 12 and day == 31 and hour == 23 and
@@ -670,13 +702,13 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                     nanoSecSinceJ2000 = int(nanoSecSinceJ2000 +
                                             CDFepoch.dTinNanoSecs)
             if (count == 1):
-                if (to_np == None):
+                if not to_np:
                     return int(nanoSecSinceJ2000)
                 else:
                     return np.array(int(nanoSecSinceJ2000))
             else:
                 nanoSecSinceJ2000s.append(int(nanoSecSinceJ2000))
-        if (to_np == None):
+        if not to_np:
             return nanoSecSinceJ2000s
         else:
             return np.array(nanoSecSinceJ2000s)
@@ -868,20 +900,29 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             encoded += str(components[9]).zfill(3)
         return encoded
 
-    def _JulianDay(y, m, d):  # @NoSelf
+    @staticmethod
+    def _JulianDay(y: int, m: int, d: int) -> int:
 
         a1 = int(7*(int(y+int((m+9)/12)))/4)
         a2 = int(3*(int(int(y+int((m-9)/7))/100)+1)/4)
         a3 = int(275*m/9)
         return (367*y - a1 - a2 + a3 + d + 1721029)
 
-    def compute_epoch16(datetimes, to_np=None):  # @NoSelf
+    @staticmethod
+    def compute_epoch16(datetimes, to_np: bool = False):
 
+<<<<<<< HEAD
         if (not isinstance(datetimes, list) and
                 not isinstance(datetimes, tuple)):
             raise ValueError('Bad input')
         if (not isinstance(datetimes[0], list) and
                 not isinstance(datetimes[0], tuple)):
+=======
+        if not isinstance(datetimes, (list, tuple)):
+            raise TypeError('Bad input')
+
+        if not isinstance(datetimes[0], (list, tuple)):
+>>>>>>> correct logic
             new_dates = []
             new_dates = [datetimes]
         else:
@@ -890,7 +931,7 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
         if (count == 0):
             return
         epochs = []
-        for x in range(0, count):
+        for x in range(count):
             epoch = []
             date = new_dates[x]
             items = len(date)
@@ -999,8 +1040,15 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                 psec = int(1000.0 * (xxx - nsec))
             else:
                 raise ValueError('Invalid epoch16 components')
+<<<<<<< HEAD
             if (year < 0):
                 raise ValueError('Illegal epoch field')
+=======
+
+            if (year < 0):
+                raise ValueError('Illegal epoch field')
+
+>>>>>>> correct logic
             if (year == 9999 and month == 12 and day == 31 and hour == 23 and
                 minute == 59 and second == 59 and msec == 999 and
                     usec == 999 and nsec == 999 and psec == 999):
@@ -1036,28 +1084,32 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                 epoch.append(epoch16_1)
             cepoch = complex(epoch[0], epoch[1])
             if (count == 1):
-                if (to_np == None):
+                if not to_np:
                     return cepoch
                 else:
                     return np.array(cepoch)
             else:
                 epochs.append(cepoch)
-        if (to_np == None):
+        if not to_np:
             return epochs
         else:
             return np.array(epochs)
 
-    def breakdown_epoch16(epochs, to_np=None):  # @NoSelf
+    @staticmethod
+    def breakdown_epoch16(epochs, to_np: bool = False):  # @NoSelf
 
-        if (isinstance(epochs, complex) or
-                isinstance(epochs, np.complex128)):
+        if isinstance(epochs, (complex, np.complex128)):
             new_epochs = [epochs]
-        elif (isinstance(epochs, list) or isinstance(epochs, tuple) or
-              isinstance(epochs, np.ndarray)):
+        elif isinstance(epochs, (list, tuple, np.ndarray)):
             new_epochs = epochs
         else:
+<<<<<<< HEAD
             raise ValueError('Bad data')
             return
+=======
+            raise TypeError('Bad data')
+
+>>>>>>> correct logic
         count = len(new_epochs)
         components = []
         for x in range(0, count):
@@ -1115,13 +1167,13 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                 component.append(component_8)
                 component.append(component_9)
             if (count == 1):
-                if (to_np == None):
+                if not to_np:
                     return component
                 else:
                     return np.array(component)
             else:
                 components.append(component)
-        if (to_np == None):
+        if not to_np:
             return components
         else:
             return np.array(components)
@@ -1317,7 +1369,8 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             encoded += str(components[6]).zfill(3)
         return encoded
 
-    def compute_epoch(dates, to_np=None):  # @NoSelf
+    @staticmethod
+    def compute_epoch(dates, to_np: bool = False):  # @NoSelf
 
         if (not isinstance(dates, list) and not isinstance(dates, tuple)):
             raise ValueError('Bad input')
@@ -1410,12 +1463,12 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             else:
                 msecInDay = (3600000 * hour) + (60000 * minute) + (1000 * second) + msec
             if (count == 1):
-                if (to_np == None):
+                if not to_np:
                     return (86400000.0*daysSince0AD+msecInDay)
                 else:
                     return np.array((86400000.0*daysSince0AD+msecInDay))
             epochs.append(86400000.0*daysSince0AD+msecInDay)
-        if (to_np == None):
+        if not to_np:
             return epochs
         else:
             return np.array(epochs)
@@ -1438,7 +1491,8 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
         else:
             return msecFromEpoch
 
-    def breakdown_epoch(epochs, to_np=False):  # @NoSelf
+    @staticmethod
+    def breakdown_epoch(epochs, to_np: bool = False):  # @NoSelf
 
         if (isinstance(epochs, float) or isinstance(epochs, np.float64)):
             new_epochs = [epochs]
@@ -1489,17 +1543,18 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                 component.append(int(second_AD % 60.0))
                 component.append(int(msec_AD % 1000.0))
             if (count == 1):
-                if (to_np):
+                if to_np:
                     return np.array(component)
                 else:
                     return component
             else:
                 components.append(component)
-        if (to_np):
+        if to_np:
             return np.array(components)
         else:
             return components
 
+    @staticmethod
     def epochrange_epoch(epochs, starttime=None, endtime=None):  # @NoSelf
 
         if (isinstance(epochs, float) or isinstance(epochs, np.float64)):
@@ -1541,7 +1596,8 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
             new_epochs = epochs
         return np.where(np.logical_and(new_epochs >= stime, new_epochs <= etime))[0]
 
-    def parse(value, to_np=None):  # @NoSelf
+    @staticmethod
+    def parse(value, to_np: bool = False):  # @NoSelf
         """
         Parses the provided date/time string(s) into CDF epoch value(s).
 
@@ -1577,12 +1633,12 @@ def to_datetime(self, cdf_time: Sequence[float], to_np: bool = False) -> List[da
                 epochs = []
                 for x in range(0, num):
                     epochs.append(CDFepoch._parse_epoch(value[x]))
-                if (to_np == None):
+                if not to_np:
                     return epochs
                 else:
                     return np.array(epochs)
             else:
-                if (to_np == None):
+                if not to_np:
                     return CDFepoch._parse_epoch(value)
                 else:
                     return np.array(CDFepoch._parse_epoch(value))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cdflib
-version = 0.4.0
+version = 0.3.13
 author = MAVEN SDC
 author_email = mavensdc@lasp.colorado.edu
 description = A python CDF reader toolkit

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cdflib
-version = 0.3.12
+version = 0.4.0
 author = MAVEN SDC
 author_email = mavensdc@lasp.colorado.edu
 description = A python CDF reader toolkit
@@ -45,8 +45,3 @@ tests =
 
 [options.entry_points]
 console_scripts =
-
-[flake8]
-max-line-length = 132
-exclude = .git,__pycache__,.eggs/,doc/,docs/,build/,dist/,archive/
-

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -6,6 +6,7 @@ from random import randint
 import pytest
 import unittest
 import numpy as np
+from datetime import datetime
 
 import cdflib
 
@@ -185,6 +186,10 @@ class CDFEpochTestCase(unittest.TestCase):
         self.assertEqual(x, "2004-03-01T12:24:22.351793238")
         parsed = cdflib.cdfepoch.parse(x)
         self.assertEqual(parsed, input_time)
+
+        Epoch = cdflib.cdfepoch()
+        self.assertEqual(Epoch.to_datetime(x),
+                         datetime(2004,3,1,12,24,22,351793238))
 
     def test_findepochrange_cdfepoch(self):
         start_time = "2013-12-01T12:24:22.000"

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -4,7 +4,7 @@ import urllib.request
 from random import randint
 
 import pytest
-import unittest
+from pytest import approx
 import numpy as np
 from datetime import datetime
 
@@ -37,212 +37,221 @@ def test_encode_cdfepoch():
     assert y == '11-Aug-1995 02:06:40.002'
 
 
-class CDFEpochTestCase(unittest.TestCase):
+def test_encode_cdfepoch16():
+    '''
+    cdf_encode_epoch16(dcomplex(63300946758.000000, 176214648000.00000)) in IDL
+    returns 04-Dec-2005 20:39:28.176.214.654.976
 
-    def test_encode_cdfepoch16(self):
-        '''
-        cdf_encode_epoch16(dcomplex(63300946758.000000, 176214648000.00000)) in IDL
-        returns 04-Dec-2005 20:39:28.176.214.654.976
+    However, I believe this IDL routine is bugged.  This website:
+    https://www.epochconverter.com/seconds-days-since-y0
 
-        However, I believe this IDL routine is bugged.  This website:
-        https://www.epochconverter.com/seconds-days-since-y0
+    shows a correct answer.
+    '''
+    x = cdflib.cdfepoch.encode(np.complex128(63300946758.000000 + 176214648000.00000j))
+    assert x == '2005-12-04T20:19:18.176214648000'
+    y = cdflib.cdfepoch.encode(np.complex128([33300946758.000000 + 106014648000.00000j,
+                                              61234543210.000000 + 000011148000.00000j]),
+                               iso_8601=False)
+    assert y[0] == '07-Apr-1055 14:59:18.106.014.648.000'
+    assert y[1] == '12-Jun-1940 03:20:10.000.011.148.000'
 
-        shows a correct answer.
-        '''
-        x = cdflib.cdfepoch.encode(np.complex128(63300946758.000000 + 176214648000.00000j))
-        self.assertEqual(x, '2005-12-04T20:19:18.176214648000')
-        y = cdflib.cdfepoch.encode(np.complex128([33300946758.000000 + 106014648000.00000j,
-                                                  61234543210.000000 + 000011148000.00000j]),
-                                   iso_8601=False)
-        self.assertEqual(y[0], '07-Apr-1055 14:59:18.106.014.648.000')
-        self.assertEqual(y[1], '12-Jun-1940 03:20:10.000.011.148.000')
 
-    def test_encode_cdftt2000(self):
-        x = cdflib.cdfepoch.encode(186999622360321123)
-        self.assertEqual(x, '2005-12-04T20:19:18.176321123')
-        y = cdflib.cdfepoch.encode([500000000100, 123456789101112131],
-                                   iso_8601=False)
-        self.assertEqual(y[0], '01-Jan-2000 12:07:15.816.000.100')
-        self.assertEqual(y[1], '30-Nov-2003 09:32:04.917.112.131')
+def test_encode_cdftt2000():
+    x = cdflib.cdfepoch.encode(186999622360321123)
+    assert x == '2005-12-04T20:19:18.176321123'
+    y = cdflib.cdfepoch.encode([500000000100, 123456789101112131],
+                               iso_8601=False)
+    assert y[0] == '01-Jan-2000 12:07:15.816.000.100'
+    assert y[1] == '30-Nov-2003 09:32:04.917.112.131'
 
-    def test_unixtime(self):
-        x = cdflib.cdfepoch.unixtime([500000000100, 123456789101112131])
-        self.assertEqual(x[0], 946728435.816)
-        self.assertEqual(x[1], 1070184724.917112)
 
-    def test_breakdown_cdfepoch(self):
-        x = cdflib.cdfepoch.breakdown([62285326000000.0, 62985326000000.0])
-        # First in the array
-        self.assertEqual(x[0][0], 1973)
-        self.assertEqual(x[0][1], 9)
-        self.assertEqual(x[0][2], 28)
-        self.assertEqual(x[0][3], 23)
-        self.assertEqual(x[0][4], 26)
-        self.assertEqual(x[0][5], 40)
-        self.assertEqual(x[0][6], 0)
-        # Second in the array
-        self.assertEqual(x[1][0], 1995)
-        self.assertEqual(x[1][1], 12)
-        self.assertEqual(x[1][2], 4)
-        self.assertEqual(x[1][3], 19)
-        self.assertEqual(x[1][4], 53)
-        self.assertEqual(x[1][5], 20)
-        self.assertEqual(x[1][6], 0)
+def test_unixtime():
+    x = cdflib.cdfepoch.unixtime([500000000100, 123456789101112131])
+    assert x[0] == 946728435.816
+    assert x[1] == 1070184724.917112
 
-    def test_breakdown_cdfepoch16(self):
-        x = cdflib.cdfepoch.breakdown(np.complex128(63300946758.000000 + 176214648000.00000j))
-        self.assertEqual(x[0], 2005)
-        self.assertEqual(x[1], 12)
-        self.assertEqual(x[2], 4)
-        self.assertEqual(x[3], 20)
-        self.assertEqual(x[4], 19)
-        self.assertEqual(x[5], 18)
-        self.assertEqual(x[6], 176)
-        self.assertEqual(x[7], 214)
-        self.assertEqual(x[8], 648)
-        self.assertEqual(x[9], 000)
 
-    def test_breakdown_cdftt2000(self):
-        x = cdflib.cdfepoch.breakdown(123456789101112131)
-        self.assertEqual(x[0], 2003)
-        self.assertEqual(x[1], 11)
-        self.assertEqual(x[2], 30)
-        self.assertEqual(x[3], 9)
-        self.assertEqual(x[4], 32)
-        self.assertEqual(x[5], 4)
-        self.assertEqual(x[6], 917)
-        self.assertEqual(x[7], 112)
-        self.assertEqual(x[8], 131)
+def test_breakdown_cdfepoch():
+    x = cdflib.cdfepoch.breakdown([62285326000000.0, 62985326000000.0])
+    # First in the array
+    assert x[0][0] == 1973
+    assert x[0][1] == 9
+    assert x[0][2] == 28
+    assert x[0][3] == 23
+    assert x[0][4] == 26
+    assert x[0][5] == 40
+    assert x[0][6] == 0
+    # Second in the array
+    assert x[1][0] == 1995
+    assert x[1][1] == 12
+    assert x[1][2] == 4
+    assert x[1][3] == 19
+    assert x[1][4] == 53
+    assert x[1][5] == 20
+    assert x[1][6] == 0
 
-    def test_compute_cdfepoch(self):
-        '''
-        Using random numbers for the compute tests
-        '''
-        random_time = []
-        random_time.append(randint(0, 2018))  # Year
-        random_time.append(randint(1, 12))  # Month
-        random_time.append(randint(1, 28))  # Date
-        random_time.append(randint(0, 23))  # Hour
-        random_time.append(randint(0, 59))  # Minute
-        random_time.append(randint(0, 59))  # Second
-        random_time.append(randint(0, 999))  # Millisecond
-        x = cdflib.cdfepoch.breakdown(cdflib.cdfepoch.compute(random_time))
-        i = 0
-        for t in x:
-            self.assertEqual(t, random_time[i], 'Time '+str(random_time) + ' was not equal to ' + str(x))
-            i += 1
 
-    def test_compute_cdfepoch16(self):
-        random_time = []
-        random_time.append(randint(0, 2018))  # Year
-        random_time.append(randint(1, 12))  # Month
-        random_time.append(randint(1, 28))  # Date
-        random_time.append(randint(0, 23))  # Hour
-        random_time.append(randint(0, 59))  # Minute
-        random_time.append(randint(0, 59))  # Second
-        random_time.append(randint(0, 999))  # Millisecond
-        random_time.append(randint(0, 999))  # Microsecond
-        random_time.append(randint(0, 999))  # Nanosecond
-        random_time.append(randint(0, 999))  # Picosecond
-        x = cdflib.cdfepoch.breakdown(cdflib.cdfepoch.compute(random_time))
-        i = 0
-        for t in x:
-            self.assertEqual(t, random_time[i], 'Time '+str(random_time) + ' was not equal to ' + str(x))
-            i += 1
+def test_breakdown_cdfepoch16():
+    x = cdflib.cdfepoch.breakdown(np.complex128(63300946758.000000 + 176214648000.00000j))
+    assert x[0] == 2005
+    assert x[1] == 12
+    assert x[2] == 4
+    assert x[3] == 20
+    assert x[4] == 19
+    assert x[5] == 18
+    assert x[6] == 176
+    assert x[7] == 214
+    assert x[8] == 648
+    assert x[9] == 000
 
-    def test_compute_cdftt2000(self):
-        random_time = []
-        random_time.append(randint(0, 2018))  # Year
-        random_time.append(randint(1, 12))  # Month
-        random_time.append(randint(1, 28))  # Date
-        random_time.append(randint(0, 23))  # Hour
-        random_time.append(randint(0, 59))  # Minute
-        random_time.append(randint(0, 59))  # Second
-        random_time.append(randint(0, 999))  # Millisecond
-        random_time.append(randint(0, 999))  # Microsecond
-        random_time.append(randint(0, 999))  # Nanosecond
-        x = cdflib.cdfepoch.breakdown(cdflib.cdfepoch.compute(random_time))
-        i = 0
-        for t in x:
-            self.assertEqual(t, random_time[i], 'Time '+str(random_time) + ' was not equal to ' + str(x))
-            i += 1
 
-    def test_parse_cdfepoch(self):
-        x = cdflib.cdfepoch.encode(62567898765432.0)
-        self.assertEqual(x, "1982-09-12T11:52:45.432")
-        parsed = cdflib.cdfepoch.parse(x)
-        self.assertEqual(parsed, 62567898765432.0)
+def test_breakdown_cdftt2000():
+    x = cdflib.cdfepoch.breakdown(123456789101112131)
+    assert x[0] == 2003
+    assert x[1] == 11
+    assert x[2] == 30
+    assert x[3] == 9
+    assert x[4] == 32
+    assert x[5] == 4
+    assert x[6] == 917
+    assert x[7] == 112
+    assert x[8] == 131
 
-    def test_parse_cdfepoch16(self):
-        input_time = np.complex(53467976543.0, 543218654100)
-        x = cdflib.cdfepoch.encode(input_time)
-        self.assertEqual(x, "1694-05-01T07:42:23.543218654100")
-        parsed = cdflib.cdfepoch.parse(x, to_np=True)
-        self.assertEqual(parsed, input_time)
 
-    def test_parse_cdftt2000(self):
-        input_time = 131415926535793238
-        x = cdflib.cdfepoch.encode(input_time)
-        self.assertEqual(x, "2004-03-01T12:24:22.351793238")
-        parsed = cdflib.cdfepoch.parse(x)
-        self.assertEqual(parsed, input_time)
+def test_compute_cdfepoch():
+    '''
+    Using random numbers for the compute tests
+    '''
+    random_time = []
+    random_time.append(randint(0, 2018))  # Year
+    random_time.append(randint(1, 12))  # Month
+    random_time.append(randint(1, 28))  # Date
+    random_time.append(randint(0, 23))  # Hour
+    random_time.append(randint(0, 59))  # Minute
+    random_time.append(randint(0, 59))  # Second
+    random_time.append(randint(0, 999))  # Millisecond
+    x = cdflib.cdfepoch.breakdown(cdflib.cdfepoch.compute(random_time))
+    i = 0
+    for t in x:
+        assert t == random_time[i], 'Time {} was not equal to {}'.format(random_time, x)
+        i += 1
 
-        Epoch = cdflib.cdfepoch()
-        self.assertEqual(Epoch.to_datetime(x),
-                         datetime(2004,3,1,12,24,22,351793238))
 
-    def test_findepochrange_cdfepoch(self):
-        start_time = "2013-12-01T12:24:22.000"
-        end_time = "2014-12-01T12:24:22.000"
-        x = cdflib.cdfepoch.parse([start_time, end_time])
-        time_array = np.arange(x[0], x[1], step=1000000)
+def test_compute_cdfepoch16():
+    random_time = []
+    random_time.append(randint(0, 2018))  # Year
+    random_time.append(randint(1, 12))  # Month
+    random_time.append(randint(1, 28))  # Date
+    random_time.append(randint(0, 23))  # Hour
+    random_time.append(randint(0, 59))  # Minute
+    random_time.append(randint(0, 59))  # Second
+    random_time.append(randint(0, 999))  # Millisecond
+    random_time.append(randint(0, 999))  # Microsecond
+    random_time.append(randint(0, 999))  # Nanosecond
+    random_time.append(randint(0, 999))  # Picosecond
+    x = cdflib.cdfepoch.breakdown(cdflib.cdfepoch.compute(random_time))
+    i = 0
+    for t in x:
+        assert t == random_time[i], 'Time {} was not equal to {}'.format(random_time, x)
+        i += 1
 
-        test_start = [2014, 8, 1, 8, 1, 54, 123]
-        test_end = [2018, 1, 1, 1, 1, 1, 1]
-        index = cdflib.cdfepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
-        # Test that the test_start is less than the first index, but more than one less
-        self.assertGreaterEqual(time_array[index[0]], cdflib.cdfepoch.compute(test_start))
-        self.assertLessEqual(time_array[index[0]-1], cdflib.cdfepoch.compute(test_start))
 
-        self.assertLessEqual(time_array[index[-1]], cdflib.cdfepoch.compute(test_end))
-        return
+def test_compute_cdftt2000():
+    random_time = []
+    random_time.append(randint(0, 2018))  # Year
+    random_time.append(randint(1, 12))  # Month
+    random_time.append(randint(1, 28))  # Date
+    random_time.append(randint(0, 23))  # Hour
+    random_time.append(randint(0, 59))  # Minute
+    random_time.append(randint(0, 59))  # Second
+    random_time.append(randint(0, 999))  # Millisecond
+    random_time.append(randint(0, 999))  # Microsecond
+    random_time.append(randint(0, 999))  # Nanosecond
+    x = cdflib.cdfepoch.breakdown(cdflib.cdfepoch.compute(random_time))
+    i = 0
+    for t in x:
+        assert t == random_time[i], 'Time {} was not equal to {}'.format(random_time, x)
+        i += 1
 
-    def test_findepochrange_cdftt2000(self):
-        start_time = "2004-03-01T12:24:22.351793238"
-        end_time = "2004-03-01T12:28:22.351793238"
-        x = cdflib.cdfepoch.parse([start_time, end_time])
-        time_array = np.arange(x[0], x[1], step=1000000)
 
-        test_start = [2004, 3, 1, 12, 25, 54, 123, 111, 98]
-        test_end = [2004, 3, 1, 12, 26, 4, 123, 456, 789]
-        index = cdflib.cdfepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
-        # Test that the test_start is less than the first index, but more than one less
-        self.assertGreaterEqual(time_array[index[0]], cdflib.cdfepoch.compute(test_start))
-        self.assertLessEqual(time_array[index[0]-1], cdflib.cdfepoch.compute(test_start))
+def test_parse_cdfepoch():
+    x = cdflib.cdfepoch.encode(62567898765432.0)
+    assert x == "1982-09-12T11:52:45.432"
+    parsed = cdflib.cdfepoch.parse(x)
+    assert parsed == approx(62567898765432.0)
 
-        self.assertLessEqual(time_array[index[-1]], cdflib.cdfepoch.compute(test_end))
-        self.assertGreaterEqual(time_array[index[-1]+1], cdflib.cdfepoch.compute(test_end))
-        return
 
-    def test_findepochrange_cdfepoch16(self):
-        start_time = "1978-03-10T03:24:22.351793238462"
-        end_time = "1978-06-13T01:28:22.338327950466"
-        x = cdflib.cdfepoch.parse([start_time, end_time])
-        first_int_step = int((x[1].real - x[0].real) / 1000)
-        second_int_step = int((x[1].imag - x[0].imag) / 1000)
-        time_array = []
-        for i in range(0, 1000):
-            time_array.append(x[0]+complex(first_int_step*i, second_int_step*i))
+def test_parse_cdfepoch16():
+    input_time = np.complex(53467976543.0, 543218654100)
+    x = cdflib.cdfepoch.encode(input_time)
+    assert x == "1694-05-01T07:42:23.543218654100"
+    parsed = cdflib.cdfepoch.parse(x, to_np=True)
+    assert parsed == input_time
 
-        test_start = [1978, 6, 10, 3, 24, 22, 351, 793, 238, 462]
-        test_end = [1978, 6, 12, 23, 11, 1, 338, 341, 416, 466]
-        index = cdflib.cdfepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
 
-        # Test that the test_start is less than the first index, but more than one less
-        self.assertGreaterEqual(time_array[index[0]].real, cdflib.cdfepoch.compute(test_start).real)
-        self.assertLessEqual(time_array[index[0]-1].real, cdflib.cdfepoch.compute(test_start).real)
-        self.assertLessEqual(time_array[index[-1]].real, cdflib.cdfepoch.compute(test_end).real)
-        self.assertGreaterEqual(time_array[index[-1]+1].real, cdflib.cdfepoch.compute(test_end).real)
+def test_parse_cdftt2000():
+    input_time = 131415926535793238
+    x = cdflib.cdfepoch.encode(input_time)
+    assert x == "2004-03-01T12:24:22.351793238"
+    parsed = cdflib.cdfepoch.parse(x)
+    assert parsed == input_time
+
+    Epoch = cdflib.cdfepoch()
+    assert Epoch.to_datetime(parsed) == datetime(2004, 3, 1, 12, 24, 22, 351793238)
+
+
+def test_findepochrange_cdfepoch():
+    start_time = "2013-12-01T12:24:22.000"
+    end_time = "2014-12-01T12:24:22.000"
+    x = cdflib.cdfepoch.parse([start_time, end_time])
+    time_array = np.arange(x[0], x[1], step=1000000)
+
+    test_start = [2014, 8, 1, 8, 1, 54, 123]
+    test_end = [2018, 1, 1, 1, 1, 1, 1]
+    index = cdflib.cdfepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
+    # Test that the test_start is less than the first index, but more than one less
+    assert time_array[index[0]] >= cdflib.cdfepoch.compute(test_start)
+    assert time_array[index[0]-1] <= cdflib.cdfepoch.compute(test_start)
+
+    assert time_array[index[-1]] <= cdflib.cdfepoch.compute(test_end)
+
+
+def test_findepochrange_cdftt2000():
+    start_time = "2004-03-01T12:24:22.351793238"
+    end_time = "2004-03-01T12:28:22.351793238"
+    x = cdflib.cdfepoch.parse([start_time, end_time])
+    time_array = np.arange(x[0], x[1], step=1000000)
+
+    test_start = [2004, 3, 1, 12, 25, 54, 123, 111, 98]
+    test_end = [2004, 3, 1, 12, 26, 4, 123, 456, 789]
+    index = cdflib.cdfepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
+    # Test that the test_start is less than the first index, but more than one less
+    assert time_array[index[0]] >= cdflib.cdfepoch.compute(test_start)
+    assert time_array[index[0]-1] <= cdflib.cdfepoch.compute(test_start)
+
+    assert time_array[index[-1]] <= cdflib.cdfepoch.compute(test_end)
+    assert time_array[index[-1]+1] >= cdflib.cdfepoch.compute(test_end)
+
+
+def test_findepochrange_cdfepoch16():
+    start_time = "1978-03-10T03:24:22.351793238462"
+    end_time = "1978-06-13T01:28:22.338327950466"
+    x = cdflib.cdfepoch.parse([start_time, end_time])
+    first_int_step = int((x[1].real - x[0].real) / 1000)
+    second_int_step = int((x[1].imag - x[0].imag) / 1000)
+    time_array = []
+    for i in range(0, 1000):
+        time_array.append(x[0]+complex(first_int_step*i, second_int_step*i))
+
+    test_start = [1978, 6, 10, 3, 24, 22, 351, 793, 238, 462]
+    test_end = [1978, 6, 12, 23, 11, 1, 338, 341, 416, 466]
+    index = cdflib.cdfepoch.findepochrange(time_array, starttime=test_start, endtime=test_end)
+
+    # Test that the test_start is less than the first index, but more than one less
+    assert time_array[index[0]].real >= cdflib.cdfepoch.compute(test_start).real
+    assert time_array[index[0]-1].real <= cdflib.cdfepoch.compute(test_start).real
+    assert time_array[index[-1]].real <= cdflib.cdfepoch.compute(test_end).real
+    assert time_array[index[-1]+1].real >= cdflib.cdfepoch.compute(test_end).real
 
 
 def test_latest_leapsecs():

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -182,11 +182,14 @@ def test_parse_cdfepoch():
 
 
 def test_parse_cdfepoch16():
-    input_time = np.complex(53467976543.0, 543218654100)
+    input_time = 53467976543.0 + 543218654100j
     x = cdflib.cdfepoch.encode(input_time)
     assert x == "1694-05-01T07:42:23.543218654100"
-    parsed = cdflib.cdfepoch.parse(x, to_np=True)
+    parsed = cdflib.cdfepoch.parse(x)
     assert parsed == input_time
+
+    assert cdflib.cdfepoch().to_datetime(parsed) == [datetime(1694, 5, 1, 7, 42, 23, 543218)]
+
 
 
 def test_parse_cdftt2000():

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -196,8 +196,7 @@ def test_parse_cdftt2000():
     parsed = cdflib.cdfepoch.parse(x)
     assert parsed == input_time
 
-    Epoch = cdflib.cdfepoch()
-    assert Epoch.to_datetime(parsed) == datetime(2004, 3, 1, 12, 24, 22, 351793238)
+    assert cdflib.cdfepoch().to_datetime(parsed) == [datetime(2004, 3, 1, 12, 24, 22, 351793)]
 
 
 def test_findepochrange_cdfepoch():


### PR DESCRIPTION
following on from #38, these changes are the other half of what my forked cdflib users need.

* datetime.datetime output option via `to_datetime()`
* Python intrinsic exceptions `raise TypeError()` `raise KeyError()` etc. instead of `return None`, as the latter breaks essential Python syntax

So consider first merging the approved #38, then this PR.

happy to discuss.