### PR TITLE
Don't fail if variable exists but has no data

### DIFF
--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -531,7 +531,7 @@ class CDF:
             return vdr_info
         else:
             if (vdr_info['max_records'] < 0):
-                raise ValueError('No data is written for this variable')
+                return
 
             return self._read_vardata(vdr_info, epoch=epoch, starttime=starttime, endtime=endtime,
                                       startrec=startrec, endrec=endrec, record_range_only=record_range_only,


### PR DESCRIPTION
There are checks earlier in the function that raise an error if the requested variable doesn't exist, but it seems reasonable (and necessary in some cases) to not fail if the variable exists but doesn't have any data.