### PR TITLE
CDFepoch.unixtime returns incorrect timestamp values due to timezone issues

### DIFF
--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -219,7 +219,7 @@ class CDFepoch:
                     date[i-1] += t[i]
                 else:
                     date[i] = t[i]
-            unixtime.append(datetime.datetime(*date).replace(tzinfo=datetime.timezone.utc).timestamp())
+            unixtime.append(datetime.datetime(*date).timestamp())
         return np.array(unixtime) if to_np else unixtime
 
     @staticmethod


### PR DESCRIPTION
The issue is 
`datetime.datetime(*date).replace(tzinfo=datetime.timezone.utc).timestamp()`

This will give different timestamp values (normally off by full hours) depending on the local time zone settings. This effect cannot be seen if your computers timezone is set to GMT.

This can be easily reproduced using:
`import datetime`
`print(datetime.datetime(2020, 1, 1).timestamp())`
`print(datetime.datetime(2020, 1, 1).replace(tzinfo=datetime.timezone.utc).timestamp())`
(when timezone is not set to GMT)