### PR TITLE
Require attrs 19.2.0 to use eq in attr.s

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ python_requires = >= 3.5
 include_package_data = True
 packages = find:
 install_requires =
+  attrs>=19.2.0
   numpy
 
 [options.extras_require]


### PR DESCRIPTION
The Travis CI build is failing for me:

```
    @attr.s(slots=True, eq=False)
TypeError: attrs() got an unexpected keyword argument 'eq'
```

https://travis-ci.com/github/hugovk/cdflib/jobs/370622148

That's because `eq` isn't in old attrs:

> New in version 19.2.0: eq and order

https://www.attrs.org/en/stable/api.html#attr.s

