### PR TITLE
Travis CI: Test on Python 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,11 @@ jobs:
     install: pip install .[tests]
     script: pytest --cov
     after_success: coveralls
+  - name: "3.9 tests"
+    python: 3.9-dev
+    install: pip install .[tests]
+    script: pytest --cov
+    after_success: coveralls
   - name: "Docs"
     python: 3.7
     install: pip install .[docs]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 group: travis_latest
+cache: pip
 
 git:
   depth: 25


### PR DESCRIPTION
Python 3.9 is in beta with the final 3.9.0 release due in October. The CPython team recommended third-party libraries test against the beta and RCs.