### PR TITLE
updated cdfread to use self in functions that call it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - run: pytest --cov
     - name: Upload Coverage (unix-like)
       run: bash <(curl -s https://codecov.io/bash)
-      if: matrix.os != "windows-latest"
+      if: matrix.os != windows-latest
     - name: Upload Coverage (Windows)
       run: Invoke-WebRequest -Uri "https://codecov.io/bash" -OutFile codecov.sh
-      if: matrix.os == "windows-latest"
+      if: matrix.os == windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,9 @@ jobs:
         python-version: '3.8'
     - run: pip install .[tests]
     - run: pytest --cov
-    - run: bash <(curl -s https://codecov.io/bash)
+    - name: Upload Coverage (unix-like)
+      run: bash <(curl -s https://codecov.io/bash)
+      if: matrix.os != "windows-latest"
+    - name: Upload Coverage (Windows)
+      run: Invoke-WebRequest -Uri "https://codecov.io/bash" -OutFile codecov.sh
+      if: matrix.os == "windows-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - run: pytest --cov
     - name: Upload Coverage (unix-like)
       run: bash <(curl -s https://codecov.io/bash)
-      if: matrix.os != windows-latest
+      if: matrix.os != 'windows-latest'
     - name: Upload Coverage (Windows)
       run: Invoke-WebRequest -Uri "https://codecov.io/bash" -OutFile codecov.sh
-      if: matrix.os == windows-latest
+      if: matrix.os == 'windows-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,10 @@ build
 *.ipynb
 /*.html
 /testing.py
-/.coverage
+tests/.coverage
+tests/.hypothesis
+tests/coverage.xml
+tests/codecov.sh
 doc/_build
 doc/api
 .eggs/*

--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -1701,11 +1701,11 @@ class CDF:
             # with sparse records
             if ('pad' in vdr_dict):
                 # use default pad value
-                filled_data = CDF._convert_np_data(vdr_dict['pad'],
-                                                   vdr_dict['data_type'],
-                                                   vdr_dict['num_elements'])
+                filled_data = self._convert_np_data(vdr_dict['pad'],
+                                                    vdr_dict['data_type'],
+                                                    vdr_dict['num_elements'])
             else:
-                filled_data = CDF._convert_np_data(
+                filled_data = self._convert_np_data(
                     self._default_pad(vdr_dict['data_type'],
                                       vdr_dict['num_elements']),
                     vdr_dict['data_type'],
@@ -2152,7 +2152,7 @@ class CDF:
             dt_string = 's'
         return dt_string
 
-    def _default_pad(self, data_type, num_elms):   # @NoSelf
+    def _default_pad(self, data_type, num_elms):
         '''
         The default pad values by CDF data type
         '''
@@ -2200,7 +2200,7 @@ class CDF:
             pass
         return ret
 
-    def _convert_np_data(data, data_type, num_elems):   # @NoSelf
+    def _convert_np_data(self, data, data_type, num_elems):
         '''
         Converts a single np data into byte stream.
         '''

--- a/tests/test_cdfread.py
+++ b/tests/test_cdfread.py
@@ -5,9 +5,9 @@ import cdflib
 
 def test_read():
     fname = 'helios.cdf'
+    url = '''http://helios-data.ssl.berkeley.edu/data/
+             E1_experiment/New_proton_corefit_data_2017/
+             cdf/helios1/1974/h1_1974_346_corefit.cdf'''
     if not os.path.exists(fname):
-        urllib.request.urlretrieve(
-            'http://helios-data.ssl.berkeley.edu/data/E1_experiment/New_proton_corefit_data_2017/cdf/helios1/1974/h1_1974_346_corefit.cdf',
-            fname,
-        )
-    cdf = cdflib.CDF(fname)
+        urllib.request.urlretrieve(url, fname)
+    cdflib.CDF(fname)

--- a/tests/test_cdfread.py
+++ b/tests/test_cdfread.py
@@ -5,9 +5,9 @@ import cdflib
 
 def test_read():
     fname = 'helios.cdf'
-    url = 'http://helios-data.ssl.berkeley.edu/data/\
-           E1_experiment/New_proton_corefit_data_2017/\
-           cdf/helios1/1974/h1_1974_346_corefit.cdf'
+    url = ("http://helios-data.ssl.berkeley.edu/data/"
+           "E1_experiment/New_proton_corefit_data_2017/"
+           "cdf/helios1/1974/h1_1974_346_corefit.cdf")
     if not os.path.exists(fname):
         urllib.request.urlretrieve(url, fname)
     cdflib.CDF(fname)

--- a/tests/test_cdfread.py
+++ b/tests/test_cdfread.py
@@ -5,9 +5,9 @@ import cdflib
 
 def test_read():
     fname = 'helios.cdf'
-    url = '''http://helios-data.ssl.berkeley.edu/data/
-             E1_experiment/New_proton_corefit_data_2017/
-             cdf/helios1/1974/h1_1974_346_corefit.cdf'''
+    url = 'http://helios-data.ssl.berkeley.edu/data/\
+           E1_experiment/New_proton_corefit_data_2017/\
+           cdf/helios1/1974/h1_1974_346_corefit.cdf'
     if not os.path.exists(fname):
         urllib.request.urlretrieve(url, fname)
     cdflib.CDF(fname)


### PR DESCRIPTION
Addressing issue #115 
the _convert_np_data function in the CDF object was a NoSelf function, however in an update in 0.3.20 a reference to self was added. I have attempted to fix this issue, but I'm not sure if all of the changes made are acceptable.

OS: Windows 10 with WSL debian 10
Python version: 3.8

tests: pytest with flake8

