### PR TITLE
Use python 3.8 for RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ build:
   image: latest
 
 python:
-  version: 3.9
+  version: 3.8
   setup_py_install: true
 
 requirements_file: requirements/docs.txt


### PR DESCRIPTION
Turns out 3.9 isn't supported yet...