### PR TITLE
fix compressed_size offset(and size)

### DIFF
--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -2243,7 +2243,7 @@ class CDF:
         section_type = int.from_bytes(block[0:4], 'big')
         if section_type == 13:
             # a CVVR
-            compressed_size = int.from_bytes(block[12:16], 'big')
+            compressed_size = int.from_bytes(block[8:16], 'big')
             return gzip.decompress(block[16:16+compressed_size])
         elif section_type == 7:
             # a VVR


### PR DESCRIPTION
according to CDFInternal Format Description  (https://spdf.gsfc.nasa.gov/pub/software/cdf/doc/cdf381/cdf38ifd.pdf), the size (cSize) of Compressed Variable Values Record (cvvr) is a 8bytes Int (16-24, which should be 8-16 here)


<img width="961" alt="Screenshot" src="https://user-images.githubusercontent.com/17849322/145011735-9dec6a90-beb4-4c4b-9dbc-251685f0e82d.png">
