### PR TITLE
Remove getVersion()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,3 +18,5 @@ Breaking changes
   instead.
 - `cdflib.cdfread.CDF.varget` no longer takes an ``inq`` argument. Instead
   use the new method `cdflib.cdfread.CDF.vdr_info` to get the VDR info.
+- ``getVersion()`` methods have been removed throughout the package. Instead
+  the CDF version can be read from class attributes.

--- a/README.md
+++ b/README.md
@@ -173,18 +173,6 @@ Get epoch range.
 Returns `list()` of the record numbers, representing the corresponding starting and ending records within the time range from the epoch data.
 `None` is returned if there is no data either written or found in the time range.
 
-### getVersion ()
-
-Shows the code version.
-
-```python
-import cdflib
-
-swea_cdf_file = cdflib.CDF('/path/to/swea_file.cdf') swea_cdf_file.cdf_info()
-
-x = swea_cdf_file.varget('NameOfVariable') swea_cdf_file.close()
-```
-
 ## CDF Writer Class
 
 ### CDF (path, cdf_spec=None, delete=False)
@@ -333,10 +321,6 @@ the form:
 [[[rec]()#1,rec_#2,rec_#3,...], [[data]()#1,data_#2,data_#3,...]]
 ```
 See the sample for its setup.
-
-### getVersion()
-
-Shows the code version and modified date.
 
 Note: The attribute entry value for the CDF epoch data type, CDF_EPOCH,
 CDF_EPOCH16 or CDF_TIME_TT2000, can be presented in either a numeric
@@ -574,10 +558,6 @@ components, corresponding to the epoch's data type.
 
 The start/end times should be in either be in epoch units, or in the
 list format described in "compute_epoch/epoch16/tt2000" section.
-
-### getVersion ()
-
-Shows the code version.
 
 ### getLeapSecondLastUpdated ()
 

--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -24,9 +24,7 @@ Sample use::
     swea_cdf_file.cdf_info()
     x = swea_cdf_file.varget('NameOfVariable')
     swea_cdf_file.close()
-    cdflib.cdfread.CDF.getVersion()
 
-@author: Bryan Harter, Michael Liu
 """
 import gzip
 import hashlib
@@ -2303,12 +2301,3 @@ class CDF:
             value_len = self._type_size(data_type, num_elems)
             return list(struct.unpack_from(form,
                                            data[0:num_recs * num_values * value_len]))
-
-    @staticmethod
-    def getVersion():
-        """
-        Prints the code version and last modified date.
-        """
-        print('CDFread version:', str(self.version) + '.' + str(self.release) +
-              '.' + str(self.increment))
-        print('Date: 2018/01/11')

--- a/cdflib/cdfwrite.py
+++ b/cdflib/cdfwrite.py
@@ -2782,27 +2782,3 @@ class CDF:
             recStart = recStart + totalRecs
 
         return sparse_data
-
-    @staticmethod
-    def getVersion():
-        """
-        Shows the code version and last modified date.
-
-        Notes
-        -----
-        The attribute entry value for the CDF epoch data type, CDF_EPOCH,
-        CDF_EPOCH16 or CDF_TIME_TT2000, can be presented in either a numeric
-        form, or an encoded string form. For numeric, the CDF_EPOCH data is
-        8-byte float, CDF_EPOCH16 16-byte complex and CDF_TIME_TT2000 8-byte
-        long. The default encoded string for the epoch data should have this
-        form:
-
-        - CDF_EPOCH: 'dd-mon-year hh:mm:ss.mmm'
-        - CDF_EPOCH16: 'dd-mon-year hh:mm:ss.mmm.uuu.nnn.ppp'
-        - CDF_TIME_TT2000: 'year-mm-ddThh:mm:ss.mmmuuunnn'
-
-        where mon is a 3-character month.
-        """
-        print('CDFwrite version:', str(self.version) + '.' + str(self.release) +
-              '.' + str(self.increment))
-        print('Date: 2018/01/11')

--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -1810,13 +1810,6 @@ class CDFepoch(object):
         else:
             return -1
 
-    def getVersion():  # @NoSelf
-        """
-        Prints the code version.
-        """
-        print('epochs version:', str(CDFepoch.version) + '.' +
-              str(CDFepoch.release) + '.' + str(CDFepoch.increment))
-
     def getLeapSecondLastUpdated():  # @NoSelf
         """
         Prints the latest date a leap second was added to the leap second table.

--- a/cdflib/epochs_astropy.py
+++ b/cdflib/epochs_astropy.py
@@ -287,11 +287,3 @@ class CDFAstropy:
             return time_list
         else:
             return np.array(time_list)
-
-    @staticmethod
-    def getVersion():
-        """
-        Prints the code version.
-        """
-        print('epochs version:', str(CDFAstropy.version) + '.' +
-              str(CDFAstropy.release) + '.' + str(CDFAstropy.increment))

--- a/doc/modules/cdfepoch.rst
+++ b/doc/modules/cdfepoch.rst
@@ -92,12 +92,6 @@ Finds the record range within the start and end time from values of a CDF epoch 
 The start/end times should be in either be in epoch units, or in the list format described in "compute_epoch/epoch16/tt2000" section.
 
 
-getVersion ()
--------------
-
-Shows the code version.
-
-
 getLeapSecondLastUpdated ()
 ----------------------------
 

--- a/doc/modules/cdfread.rst
+++ b/doc/modules/cdfread.rst
@@ -139,8 +139,3 @@ epochrange()
 
 Get epoch range. Returns ``list()`` of the record numbers, representing the corresponding starting and ending records within the time range from the epoch data.
 ``None`` is returned if there is no data either written or found in the time range.
-
-getVersion()
--------------
-
-Shows the code version

--- a/doc/modules/cdfwrite.rst
+++ b/doc/modules/cdfwrite.rst
@@ -110,10 +110,6 @@ Optional Keys:
     >>> CDF_EPOCH16: 'dd-mon-year hh:mm:ss.mmm.uuu.nnn.ppp'
     >>> CDF_TIME_TT2000: 'year-mm-ddThh:mm:ss.mmmuuunnn'
 
-getVersion()
-------------
-Shows the code version and modified date.
-
 
 Sample Usage
 ------------


### PR DESCRIPTION
This code all seems redundant and an extra maintenance burden - the user can just get the version from class attributes.