### PR TITLE
Now uses Majority from cdf_spec when writing new CDFs

### DIFF
--- a/cdflib/cdfwrite.py
+++ b/cdflib/cdfwrite.py
@@ -179,8 +179,9 @@ class CDF:
     def __init__(self, path, cdf_spec=None, delete=False):
         path = pathlib.Path(path).expanduser()
 
-        major = cdf_spec.get('Majority', 'column_major')
+        major = 1
         if cdf_spec is not None:
+            major = cdf_spec.get('Majority', 'column_major')
             if (isinstance(major, str)):
                 major = self._majority_token(major)
 

--- a/cdflib/cdfwrite.py
+++ b/cdflib/cdfwrite.py
@@ -179,7 +179,7 @@ class CDF:
     def __init__(self, path, cdf_spec=None, delete=False):
         path = pathlib.Path(path).expanduser()
 
-        major = 1
+        major = cdf_spec.get('Majority', 'column_major')
         if cdf_spec is not None:
             if (isinstance(major, str)):
                 major = self._majority_token(major)


### PR DESCRIPTION
When writing a CDF, the documentation states that a user can include a Majority value in the cdf_spec dictionary to specify if the data is row or column major. It seems like this value was never being read in the code, so I have corrected this.