### PR TITLE
Update cdfread.py

### DIFF
--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -178,9 +178,9 @@ class CDF:
     def __del__(self):
         # This implicitly will delete a temporary uncompressed file if we
         # created it earlier.
+        self._f.close()
         if self.temp_file is not None:
             os.remove(self.temp_file)
-        self._f.close()
 
     def __getitem__(self, variable: str) -> np.ndarray:
         return self.varget(variable)


### PR DESCRIPTION
Close the temporary file before deleting it.

Problem: When reading a compressed cdf file, a temporary file is created.  The cdfread.py attempts to delete the file before closing it.  This results in the following error message, "PermissionError: [WinError 32] The process cannot access the file because it is being used by another process," and the file remains open.  Closing the file before deleting fixes this problem.   