### PR TITLE
Adds automatic support for libdeflate which yields at least a 2x speedup

### DIFF
--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -1,4 +1,4 @@
-import gzip
+from .gzip_wrapper import gzip_inflate
 import hashlib
 import io
 import os
@@ -579,7 +579,7 @@ class CDF:
 
         if cType == 5:
             self._f.seek(data_start)
-            decompressed_data = gzip.decompress(self._f.read(data_size))
+            decompressed_data = gzip_inflate(self._f.read(data_size))
         elif cType == 1:
             self._f.seek(data_start)
             decompressed_data = self._uncompress_rle(self._f.read(data_size))
@@ -1982,7 +1982,7 @@ class CDF:
         if section_type == 13:
             # a CVVR
             compressed_size = int.from_bytes(block[8:16], "big")
-            return gzip.decompress(block[16 : 16 + compressed_size])
+            return gzip_inflate(block[16 : 16 + compressed_size])
         elif section_type == 7:
             # a VVR
             return block[4:]
@@ -2001,7 +2001,7 @@ class CDF:
         if section_type == 13:
             # a CVVR
             compressed_size = int.from_bytes(block[8:12], "big")
-            return gzip.decompress(block[12 : 12 + compressed_size])
+            return gzip_inflate(block[12 : 12 + compressed_size])
         elif section_type == 7:
             # a VVR
             return block[4:]

--- a/cdflib/cdfwrite.py
+++ b/cdflib/cdfwrite.py
@@ -1,5 +1,5 @@
 import binascii
-import gzip
+from .gzip_wrapper import  gzip_deflate
 import hashlib
 import io
 import logging
@@ -1031,7 +1031,7 @@ class CDF:
                     endrec = recs - 1
                     endloc = len(data)
                 bdata = data[startloc:endloc]
-                cdata = gzip.compress(bdata, compression)
+                cdata = gzip_deflate(bdata, compression)
                 if len(cdata) < len(bdata):
                     n1offset = self._write_cvvr(f, cdata)
                 else:
@@ -2065,7 +2065,7 @@ class CDF:
         uSize = len(data)
         section_type = self.CCR_
         rfuA = 0
-        cData = gzip.compress(data, level)
+        cData = gzip_deflate(data, level)
         block_size = self.CCR_BASE_SIZE64 + len(cData)
         cprOffset = 0
         ccr1 = bytearray(32)

--- a/cdflib/gzip_wrapper.py
+++ b/cdflib/gzip_wrapper.py
@@ -1,0 +1,7 @@
+try:
+    from deflate import gzip_decompress as gzip_inflate
+    from deflate import gzip_compress as gzip_deflate
+
+except ImportError:
+    from gzip import decompress as gzip_inflate
+    from gzip import compress as gzip_deflate


### PR DESCRIPTION
This PR allows to use deflate package when available. It could be added later a either dependency or optional dependency.
Here are some speedup examples:

Without libdeflate:
```
In [12]: %timeit cdflib.CDF("/home/jeandet/Downloads/bigcdf_compressed.cdf").varget("temp")
5.35 s ± 33.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [13]: %timeit cdflib.CDF("/home/jeandet/cdf_benchmarks/solo_l3_rpw-bia-efield_20220906_v01.cdf").varget("EDC_SRF")
786 ms ± 5.26 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

With libdeflate:
```
In [8]: %timeit cdflib.CDF("/home/jeandet/Downloads/bigcdf_compressed.cdf").varget("temp")
1.19 s ± 23.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [9]: %timeit cdflib.CDF("/home/jeandet/cdf_benchmarks/solo_l3_rpw-bia-efield_20220906_v01.cdf").varget("EDC_SRF")
503 ms ± 5.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```