### PR TITLE
Use nanosecond precision when returning datetime64 objects from to_datetime()

### DIFF
--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -185,7 +185,7 @@ class CDFepoch:
         """
         times = cls.breakdown(cdf_time)
         times = np.atleast_2d(times)
-        return cls._compose_date(*times.T[:9]).astype("datetime64[us]")
+        return cls._compose_date(*times.T[:9]).astype("datetime64[ns]")
 
     @staticmethod
     def unixtime(cdf_time: npt.ArrayLike) -> Union[float, npt.NDArray]:


### PR DESCRIPTION
to_datetime() currently returns numpy datetime64 objects with microsecond precision.  This causes warnings when passing them to the xarray DataArray constructor.   See: https://github.com/MAVENSDC/cdflib/issues/236

Changing to nanosecond precision eliminates the warnings.