### PR TITLE
Fix compatibility with numpy 2.0 (and add devdeps tests to CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,16 @@ jobs:
       envs: |
         - linux: py38-oldestdeps
         - linux: py39-online
-        - linux: py310
-        - linux: py311
+        #- linux: py310
+        #- linux: py311
         - linux: py312-devdeps
-        - windows: py38
-        - windows: py39
+        #- windows: py38
+        #- windows: py39
         - windows: py310
-        - windows: py311
-        - windows: py312
-        - macos: py38
-        - macos: py39
-        - macos: py310
+        #- windows: py311
+        #- windows: py312
+        #- macos: py38
+        #- macos: py39
+        #- macos: py310
         - macos: py311
-        - macos: py312
+        #- macos: py312

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,30 +8,10 @@ on:
   # Allow manual runs through the web UI
   workflow_dispatch:
 
-<<<<<<< numpy2-and-tox
 # Only allow one run per git ref at a time
 concurrency:
   group: '${{ github.workflow }}-${{ github.ref }}'
   cancel-in-progress: true
-=======
-jobs:
-  tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
-    steps:
-    - uses: actions/checkout@v3
-
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install package and test requirements
-      run: |
-        pip install -e .[tests]
-        pip check
->>>>>>> main
 
 jobs:
   core:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,30 +2,36 @@ name: Run tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - 'main'
   pull_request:
-    branches: [ main ]
+  # Allow manual runs through the web UI
+  workflow_dispatch:
+
+# Only allow one run per git ref at a time
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
 
 jobs:
-  tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
-    steps:
-    - uses: actions/checkout@v3
-
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install package and test requirements
-      run: |
-        pip install -e .[tests]
-        pip check
-
-    - name: Run tests
-      run: pytest --cov=cdflib
-
-    - name: Upload code coverage
-      uses: codecov/codecov-action@v3
+  core:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      submodules: false
+      coverage: codecov
+      envs: |
+        - linux: py38-oldestdeps
+        - linux: py39-online
+        - linux: py310
+        - linux: py311
+        - linux: py312-devdeps
+        - windows: py38
+        - windows: py39
+        - windows: py310
+        - windows: py311
+        - windows: py312
+        - macos: py38
+        - macos: py39
+        - macos: py310
+        - macos: py311
+        - macos: py312

--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -1739,7 +1739,7 @@ class CDF:
 
         # Put the data into system byte order
         if self._convert_option() != "=":
-            ret = ret.byteswap().newbyteorder()
+            ret = ret.view(ret.dtype.newbyteorder()).byteswap()
 
         if self._majority == "Column_major":
             if dimensions is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ tests =
   pytest-cov
   pytest-remotedata
   xarray
+  h5netcdf
 docs =
   astropy
   xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,11 +41,8 @@ tests =
   pytest-cov
   pytest-remotedata
   xarray
-<<<<<<< numpy2-and-tox
   h5netcdf
-=======
   netcdf4
->>>>>>> main
 docs =
   astropy
   xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,10 +15,11 @@ classifiers =
   Environment :: Console
   Intended Audience :: Science/Research
   Operating System :: OS Independent
-  Programming Language :: Python :: 3.6
-  Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
   Programming Language :: Python :: 3 :: Only
   Topic :: Utilities
 license_file = LICENSE
@@ -26,11 +27,11 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.8
 include_package_data = True
 packages = find:
 install_requires =
-  numpy
+  numpy >= 1.21
 
 [options.extras_require]
 tests =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,69 @@
 [tox]
-envlist = py36, py37, py38, py39, py310
+min_version = 4.0
+envlist =
+    py{38,39,310,311,312}{,-online}
+    py38-oldestdeps
+    py312-devdeps
+    build_docs
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}
+# tox environments are constructed with so-called 'factors' (or terms)
+# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
+# will only take effect if that factor is included in the environment name. To
+# see a list of example environments that can be run, along with a description,
+# run:
+#
+#     tox -l -v
+#
+description =
+    run tests
+    oldestdeps: with the oldest supported version of key dependencies
+    devdeps: with the latest developer version of key dependencies
+    online: that require remote data (as well as the offline ones)
 
-commands = python setup.py test
+# Run the tests in a temporary directory to not pollute the working directory with files or other downloads
+changedir = .tmp/{envname}
+
+# Pass through the following environment variables which may be needed for the CI
+pass_env =
+    # A variable to tell tests we are on a CI system
+    CI
+    # Custom compiler locations (such as ccache)
+    CC
+    # Location of locales (needed by sphinx on some systems)
+    LOCALE_ARCHIVE
+    # If the user has set a LC override we should follow it
+    # (note LANG is automatically passed through by tox)
+    LC_ALL
+
+set_env =
+    PYTEST_COMMAND = pytest --cov=cdflib {toxinidir}/tests/ {toxinidir}/doc/
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+
+deps =
+    oldestdeps: minimum_dependencies
+    devdeps: astropy>=0.0.dev0
+    devdeps: numpy>=0.0.dev0
+    devdeps: pandas>=0.0.dev0  # needed to prevent pandas pulling in numpy<2, this can be removed after pandas does a release supporting 2.0
+
+# The following indicates which extras_require from setup.cfg will be installed
+extras =
+    tests
+
+commands_pre =
+    oldestdeps: minimum_dependencies cdflib --filename requirements-min.txt
+    oldestdeps: pip install -r requirements-min.txt
+    pip freeze
+
+commands =
+    !online: {env:PYTEST_COMMAND} {posargs}
+    online: {env:PYTEST_COMMAND} --remote-data=any {posargs}
+
+[testenv:build_docs]
+description = invoke sphinx-build to build the HTML docs
+change_dir =
+    doc
+extras =
+    docs
+commands =
+    sphinx-build -j auto --color -W --keep-going -b html -d _build/.doctrees . _build/html {posargs}


### PR DESCRIPTION
This fixes #243 

Firstly, apologies for the slight yak shaving expedition I did into refactoring your CI. I have moved your CI config over to use tox and the [OpenAstronomy tox reuseable workflow](https://github.com/OpenAstronomy/github-actions-workflows). I am happy to either revert this if you don't like it, or to double down and also migrate your publish workflow to use it as well!

The reason I did this is to add a CI build which installs the development wheels of numpy and astropy to test against upcoming changes in those libraries. I also configured a build which uses `--remote-data` with the `-online` tox factor.