### PR TITLE
Update cdfwrite.py to correct false negative

### DIFF
--- a/cdflib/cdfwrite.py
+++ b/cdflib/cdfwrite.py
@@ -2549,7 +2549,7 @@ class CDF:
         or if any pre-processing needs to occur. Numbers and datetime64 objects can be immediately converted.
         """
         if hasattr(obj, "__len__"):
-            return bool(all(obj)) and all((isinstance(elem, numbers.Number) or isinstance(elem, np.datetime64)) for elem in obj)
+            return all((isinstance(elem, numbers.Number) or isinstance(elem, np.datetime64)) for elem in obj)
         else:
             return isinstance(obj, numbers.Number) or isinstance(obj, np.datetime64)
 


### PR DESCRIPTION
Remove the bool(all(obj)) check in the _checkListofNums() method.

Now it will correctly return 'True' if passed an list like [22, 5, 0] Before, it would fail because the 0 evaluated to False

Closes issue #235 