### PR TITLE
Update cdfwrite to include a more intelligent error message

### DIFF
--- a/cdflib/cdfwrite.py
+++ b/cdflib/cdfwrite.py
@@ -2285,7 +2285,6 @@ class CDF:
         odata : byte stream
             The stream of bytes to write to the CDF file
         """
-        print(f"Datatype: {data_type}, num_elems: {num_elems}, num_values: {num_values}, indata: {indata}")
         recSize = self._datatype_size(data_type, num_elems) * num_values
         # List or Tuple data
         if isinstance(indata, list) or isinstance(indata, tuple):

--- a/cdflib/cdfwrite.py
+++ b/cdflib/cdfwrite.py
@@ -2285,7 +2285,7 @@ class CDF:
         odata : byte stream
             The stream of bytes to write to the CDF file
         """
-
+        print(f"Datatype: {data_type}, num_elems: {num_elems}, num_values: {num_values}, indata: {indata}")
         recSize = self._datatype_size(data_type, num_elems) * num_values
         # List or Tuple data
         if isinstance(indata, list) or isinstance(indata, tuple):
@@ -2393,10 +2393,14 @@ class CDF:
                         complex_data.append(indata.imag)
                     indata = complex_data
                 form = tofrom + str(recs * num_values * num_elems) + dt_string
-                if recs * num_values * num_elems > 1:
-                    return recs, struct.pack(form, *indata)
-                else:
-                    return recs, struct.pack(form, indata)
+                try:
+                    if recs * num_values * num_elems > 1:
+                        return recs, struct.pack(form, *indata)
+                    else:
+                        return recs, struct.pack(form, indata)
+                except struct.error:
+                    raise ValueError("Unable to convert data to CDF format, data "
+                                     "object cannot be of type string.")
 
     def _num_values(self, zVar: bool, varNum: int) -> int:
         """

--- a/tests/test_cdfwrite.py
+++ b/tests/test_cdfwrite.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 import numpy as np
+import pytest
 
 from cdflib import cdfread, cdfwrite
 
@@ -43,7 +44,8 @@ def test_checksum(tmp_path):
     varatts["Attribute1"] = 1
     varatts["Attribute2"] = "500"
 
-    tfile.write_var(var_spec, var_attrs=varatts, var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+    tfile.write_var(var_spec, var_attrs=varatts,
+                    var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 
     tfile.close()
 
@@ -250,13 +252,15 @@ def test_create_zvariables_with_attributes(tmp_path):
     varatts["Attribute2"] = "500"
 
     tfile = cdf_create(fn, {"rDim_sizes": [1]})
-    tfile.write_var(var_spec, var_attrs=varatts, var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+    tfile.write_var(var_spec, var_attrs=varatts,
+                    var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 
     var_spec["Variable"] = "Variable2"
     varatts2: Dict[str, Any] = {}
     varatts2["Attribute1"] = 2
     varatts2["Attribute2"] = "1000"
-    tfile.write_var(var_spec, var_attrs=varatts2, var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+    tfile.write_var(var_spec, var_attrs=varatts2,
+                    var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 
     tfile.close()
 
@@ -348,7 +352,9 @@ def test_sparse_virtual_zvariable_blocking(tmp_path):
     physical_records2 = np.linspace(20001, 30000, num=10000)
     physical_records3 = np.linspace(50001, 60000, num=10000)
     physical_records4 = np.linspace(70001, 140000, num=70000)
-    physical_records = np.concatenate((physical_records1, physical_records2, physical_records3, physical_records4)).astype(int)
+    physical_records = np.concatenate((physical_records1, physical_records2,
+                                       physical_records3, physical_records4)).astype(
+        int)
     sparse_data = [physical_records, data]
 
     tfile = cdf_create(fn, {"rDim_sizes": [1]})
@@ -384,7 +390,9 @@ def test_sparse_zvariable_blocking(tmp_path):
     physical_records2 = np.linspace(20001, 30000, num=10000)
     physical_records3 = np.linspace(50001, 60000, num=10000)
     physical_records4 = np.linspace(70001, 140000, num=70000)
-    physical_records = np.concatenate((physical_records1, physical_records2, physical_records3, physical_records4)).astype(int)
+    physical_records = np.concatenate((physical_records1, physical_records2,
+                                       physical_records3, physical_records4)).astype(
+        int)
     sparse_data = [physical_records, data]
 
     tfile = cdf_create(fn, {"rDim_sizes": [1]})
@@ -414,7 +422,8 @@ def test_sparse_zvariable_pad(tmp_path):
     var_spec["Rec_Vary"] = True
     var_spec["Dim_Sizes"] = []
     var_spec["Sparse"] = "pad_sparse"
-    data = [[200, 3000, 3100, 3500, 4000, 5000, 6000, 10000, 10001, 10002, 20000], np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])]
+    data = [[200, 3000, 3100, 3500, 4000, 5000, 6000, 10000, 10001, 10002, 20000],
+            np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])]
 
     tfile = cdf_create(fn, {"rDim_sizes": [1]})
     tfile.write_var(var_spec, var_data=data)
@@ -443,7 +452,8 @@ def test_sparse_zvariable_previous(tmp_path):
     var_spec["Rec_Vary"] = True
     var_spec["Dim_Sizes"] = []
     var_spec["Sparse"] = "prev_sparse"
-    data = [[200, 3000, 3100, 3500, 4000, 5000, 6000, 10000, 10001, 10002, 20000], np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])]
+    data = [[200, 3000, 3100, 3500, 4000, 5000, 6000, 10000, 10001, 10002, 20000],
+            np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])]
 
     tfile = cdf_create(fn, {"rDim_sizes": [1]})
     tfile.write_var(var_spec, var_data=data)
@@ -476,7 +486,9 @@ def test_create_2d_rvariable(tmp_path):
 
     tfile = cdf_create(fn, {"rDim_sizes": [2, 2]})
     tfile.write_var(
-        var_spec, var_data=np.array([[[0, 1], [1, 2]], [[2, 3], [3, 4]], [[4, 5], [5, 6]], [[6, 7], [7, 8]], [[8, 9], [9, 10]]])
+        var_spec, var_data=np.array(
+            [[[0, 1], [1, 2]], [[2, 3], [3, 4]], [[4, 5], [5, 6]], [[6, 7], [7, 8]],
+             [[8, 9], [9, 10]]])
     )
     tfile.close()
 
@@ -510,7 +522,8 @@ def test_create_2d_rvariable_dimvary(tmp_path):
 
     tfile = cdf_create(fn, {"rDim_sizes": [2, 20]})
 
-    tfile.write_var(var_spec, var_data=np.array([[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]))
+    tfile.write_var(var_spec,
+                    var_data=np.array([[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]))
 
     tfile.close()
 
@@ -541,14 +554,16 @@ def test_create_2d_r_and_z_variables(tmp_path):
     var_spec["Dim_Vary"] = [True, False]
 
     tfile = cdf_create(fn, {"rDim_sizes": [2, 20]})
-    tfile.write_var(var_spec, var_data=np.array([[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]))
+    tfile.write_var(var_spec,
+                    var_data=np.array([[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]))
 
     var_spec["Variable"] = "Variable2"
     var_spec["Var_Type"] = "zvariable"
     varatts: Dict[str, Any] = {}
     varatts["Attribute1"] = 2
     varatts["Attribute2"] = "1000"
-    tfile.write_var(var_spec, var_attrs=varatts, var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+    tfile.write_var(var_spec, var_attrs=varatts,
+                    var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 
     tfile.close()
     # Open the file to read
@@ -590,7 +605,8 @@ def test_create_zvariables_with_attributes_to_convert(tmp_path):
     varatts["Attribute3"] = [700, "CDF_INT8"]
 
     tfile = cdf_create(fn, {"rDim_sizes": [1]})
-    tfile.write_var(var_spec, var_attrs=varatts, var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+    tfile.write_var(var_spec, var_attrs=varatts,
+                    var_data=np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 
     tfile.close()
 
@@ -620,7 +636,8 @@ def test_create_zvariables_with_data_to_convert(tmp_path):
     var_spec["Dim_Sizes"] = []
 
     tfile = cdf_create(fn, {"rDim_sizes": [1]})
-    tfile.write_var(var_spec, var_data=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    tfile.write_var(var_spec,
+                    var_data=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
 
     tfile.close()
 
@@ -630,3 +647,11 @@ def test_create_zvariables_with_data_to_convert(tmp_path):
     # Test CDF info
     var = reader.varget("Variable1")
     assert var[3] == 3
+
+
+def test_convert_data_error(tmp_path):
+    indata = int(-9223372036854775808)
+    cdf = cdfwrite.CDF(tmp_path / "test.cdf", cdf_spec={"rDim_sizes": [1]})
+    with pytest.raises(ValueError):
+        # Data from list of strings with dimension "epoch"
+        output = cdf._convert_data(51, 1, 1, indata)


### PR DESCRIPTION
I encountered an unclear error message when using cdflib, so this PR is to suggest a new wording that makes it clear to the end user what is going on. 

It is possible that this should not even throw an error, and that the use case is valid, in which case I can add a new path in _convert_data to accommodate it. There is an existing path for CDF_CHAR data types, but only if the input is a list type, which in my case it was not. 

I also think this is not a good error message and would appreciate suggestions for rewording. 

I also reformatted the test file, the only changes I made are the new test at the bottom. Let me know if you'd prefer I remove the reformatted pieces.

I also added a test to demonstrate the issue, but I also have reproducible code: 

```
test_attrs = {'Project': 'STP>Solar-Terrestrial Physics', 'Source_name': 'IMAP>Interstellar Mapping and Acceleration Probe', 'Discipline': 'Solar Physics>Heliospheric Physics', 'Mission_group': 'IMAP>Interstellar Mapping and Acceleration Probe', 'PI_name': 'Dr. David J. McComas', 'PI_affiliation': ('Princeton Plasma Physics Laboratory', '100 Stellarator Road, Princeton, NJ 08540'), 'File_naming_convention': 'source_descriptor_datatype_yyyyMMdd_vNNN', 'Data_version': 'v001', 'Descriptor': 'GLOWS>GLObal Solar Wind Structure', 'TEXT': '.', 'Instrument_type': 'Photons (space)', 'Logical_file_id': ['FILL ME IN AT FILE CREATION'], 'Data_type': 'L1A_de>Level-1A direct event', 'Logical_source': 'imap_glows_l1a_de', 'Logical_source_description': 'IMAP Mission GLOWS Direct Event Level-1A Data.'}

time_data = np.arange(np.datetime64('2022-01-01'), np.datetime64('2022-01-02'), np.timedelta64(1, 'h'), dtype='datetime64[ns]')

epoch_attrs = {
        "CATDESC": "Time, number of nanoseconds since J2000 with leap seconds included",
        "FIELDNAM": "epoch",
        "FILLVAL": np.iinfo(np.int64).min,
        "LABLAXIS": "epoch",
        "FORMAT": "I6",  # Supposedly not required, fails in xarray_to_cdf
        "UNITS": "ns",
        "VALIDMIN": np.iinfo(np.int64).min,
        "VALIDMAX": np.iinfo(np.int64).max,
        "VAR_TYPE": "support_data",
        "SCALETYP": "linear",
        "MONOTON": "INCREASE",
        "TIME_BASE": "J2000",
        "TIME_SCALE": "Terrestrial Time",
        "REFERENCE_POSITION": "Rotating Earth Geoid",
    }

epoch_time = xr.DataArray(
        time_data,
        name="epoch",
        dims=["epoch"],
        attrs=epoch_attrs
    )

output = xr.Dataset(coords={"epoch": epoch_time}, attrs=test_attrs)

# This generates the data that produces an error
test_data = np.array([str(d) for d in range(len(time_data))])

metadata_attrs = {'CATDESC': None, 'DISPLAY_TYPE': 'time_series', 'FIELDNAM': None, 'FILLVAL': -9223372036854775808, 'FORMAT': 'I6', 'LABLAXIS': 'Metadata', 'UNITS': 'nT', 'VALIDMIN': -9223372036854775808, 'VALIDMAX': 9223372036854775807, 'VAR_TYPE': 'metadata', 'SCALETYP': 'linear', 'DEPEND_0': 'epoch'}


output["metadata"] = xr.DataArray(
        test_data,
        name="metadata",
        dims=["epoch"],
        coords={"epoch": epoch_time},
        attrs=metadata_attrs
    )

xarray_to_cdf(output, "test.cdf")
```