### PR TITLE
Updated AWS reads to allow anon access for datasets such as NASA TOPS

### DIFF
--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -2042,9 +2042,9 @@ class CDF:
         elif filetype == "s3":
             try:
                 import boto3
-                from botocore.handlers import disable_signing
-                from botocore.client import Config
                 from botocore import UNSIGNED
+                from botocore.client import Config
+                from botocore.handlers import disable_signing
             except:
                 raise ImportError("boto3/botocore package not installed")
             s3parts = filename.split("/")  # 0-1=s3://, 2=bucket, 3+=key

--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -2056,7 +2056,7 @@ class CDF:
                 try:
                     obj = s3c.Object(bucket_name=mybucket, key=mykey)
                 except:
-                    s3c.meta.client.meta.events.register('choose-signer.s3.*',disable_signing)
+                    s3c.meta.client.meta.events.register("choose-signer.s3.*", disable_signing)
                     obj = s3c.Object(bucket_name=mybucket, key=mykey)
                 bdata = S3object(obj)  # type: ignore
             else:
@@ -2065,7 +2065,7 @@ class CDF:
                 try:
                     obj = s3c.get_object(Bucket=mybucket, Key=mykey)
                 except:
-                    s3c = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+                    s3c = boto3.client("s3", config=Config(signature_version=UNSIGNED))
                     obj = s3c.get_object(Bucket=mybucket, Key=mykey)
                 bdata = s3_fetchall(obj)
             return bdata


### PR DESCRIPTION
Modified 'cdfread' in the part for reading from AWS S3 to allow anonymous access for datasets such as NASA TOPS.  If users do not have an AWS access, the try/except then re-fetches the data using the anonymous/unsigned.  Tested on HelioCloud's public 2PB data store at s3://gov-nasa-hdrl-data1/, also useful for people with their own S3 datasets.  Does not affect nor break any non-S3 functionality.