### PR TITLE
Add xarray_to_cdf support for uncompressed epoch variables

### DIFF
--- a/cdflib/xarray/xarray_to_cdf.py
+++ b/cdflib/xarray/xarray_to_cdf.py
@@ -1,7 +1,7 @@
 import os
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -141,6 +141,13 @@ def _is_istp_epoch_variable(var_name: str) -> Union[re.Match, None]:
     epoch_regex_1 = re.compile("epoch$")
     epoch_regex_2 = re.compile("epoch_[0-9]+$")
     return epoch_regex_1.match(var_name.lower()) or epoch_regex_2.match(var_name.lower())
+
+
+def _variable_compression(var_name: str, compression: int, compression_skip_vars: List[str]) -> int:
+    if _is_istp_epoch_variable(var_name) or var_name in compression_skip_vars:
+        return 0
+
+    return compression
 
 
 def _dtype_to_cdf_type(var: xr.DataArray, terminate_on_warning: bool = False) -> Tuple[int, int]:
@@ -901,6 +908,7 @@ def xarray_to_cdf(
     auto_fix_depends: bool = True,
     record_dimensions: List[str] = ["record0"],
     compression: int = 0,
+    compression_skip_vars: Optional[List[str]] = None,
     nan_to_fillval: bool = True,
 ) -> None:
     """
@@ -924,6 +932,9 @@ def xarray_to_cdf(
         If the code cannot determine which dimensions should be made into CDF records, you may provide a list of them here
     compression : int, optional
         The level of compression to gzip the data in the variables.  Default is no compression, standard is 6.
+    compression_skip_vars : list of str, optional
+        Additional variables to write without compression when compression is enabled. ISTP epoch variables named
+        "epoch" or "epoch_N" are always written without compression.
     nan_to_fillval : bool, optional
         Convert all np.nan and np.datetime64('NaT') to the standard CDF FILLVALs.
 
@@ -1070,6 +1081,8 @@ def xarray_to_cdf(
         _warn_or_except(f"{file_name} already exists, cannot create CDF file.  Returning...", terminate_on_warning)
         return
 
+    compression_skip_vars = compression_skip_vars or []
+
     # Make a deep copy of the data before continuing
     dataset = xarray_dataset.copy()
 
@@ -1186,7 +1199,7 @@ def xarray_to_cdf(
                 "Num_Elements": cdf_num_elements,
                 "Rec_Vary": record_vary,
                 "Dim_Sizes": dim_sizes,
-                "Compress": compression,
+                "Compress": _variable_compression(var, compression, compression_skip_vars),
             }
 
             x.write_var(var_spec, var_attrs=var_att_dict, var_data=var_data)

--- a/tests/test_xarray_reader_writer.py
+++ b/tests/test_xarray_reader_writer.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from cdflib import CDF
 from cdflib.xarray import cdf_to_xarray, xarray_to_cdf
 
 # To run these tests use `pytest --remote-data`
@@ -362,6 +363,42 @@ def test_depend_0_round_trip_stays_string(tmp_path):
 
     assert out["data"].attrs["DEPEND_0"] == "Epoch"
     assert not isinstance(out["data"].attrs["DEPEND_0"], np.datetime64)
+
+
+def test_xarray_to_cdf_skips_epoch_compression_by_default(tmp_path):
+    pytest.importorskip("xarray")
+
+    epoch_data = np.array(["2001-01-01T00:00:00", "2001-01-01T00:00:01"], dtype="datetime64[ns]")
+    epoch = xr.Variable(["epoch"], epoch_data)
+    epoch_1 = xr.Variable(["epoch"], epoch_data)
+    data = xr.Variable(["epoch"], [1.0, 2.0], {"DEPEND_0": "epoch", "VAR_TYPE": "data"})
+    ds = xr.Dataset(data_vars={"data": data, "epoch": epoch, "epoch_1": epoch_1})
+
+    file_path = tmp_path / "epoch_compression.cdf"
+
+    xarray_to_cdf(ds, file_path, istp=False, compression=6)
+
+    with CDF(file_path) as cdf:
+        assert cdf.varinq("epoch").Compress == 0
+        assert cdf.varinq("epoch_1").Compress == 0
+        assert cdf.varinq("data").Compress == 6
+
+
+def test_xarray_to_cdf_compression_skip_vars(tmp_path):
+    pytest.importorskip("xarray")
+
+    epoch_data = np.array(["2001-01-01T00:00:00", "2001-01-01T00:00:01"], dtype="datetime64[ns]")
+    epoch = xr.Variable(["epoch"], epoch_data)
+    data = xr.Variable(["epoch"], [1.0, 2.0], {"DEPEND_0": "epoch", "VAR_TYPE": "data"})
+    ds = xr.Dataset(data_vars={"data": data, "epoch": epoch})
+
+    file_path = tmp_path / "compression_skip_vars.cdf"
+
+    xarray_to_cdf(ds, file_path, istp=False, compression=6, compression_skip_vars=["data"])
+
+    with CDF(file_path) as cdf:
+        assert cdf.varinq("epoch").Compress == 0
+        assert cdf.varinq("data").Compress == 0
 
 
 def test_smoke(cdf_path, tmp_path):


### PR DESCRIPTION
## Summary

This updates `xarray_to_cdf()` so ISTP epoch variables named `epoch` or `epoch_N` are written without gzip compression, even when variable compression is enabled for the rest of the CDF.

This addresses an ISTP/SPDF validation issue found in IMAP generated CDFs:

- Original IMAP epoch compression issue: https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/2894
- Broader IMAP ISTP metadata cleanup tracking issue: https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/2577
- I believe this PR introduced the bug in imap_processing by turning on compression: https://github.com/IMAP-Science-Operations-Center/imap_processing/pull/1886

When running CDF files through the [CDF checker](https://spdf.gsfc.nasa.gov/skteditor/CmdLineCdfCheckers.html) command line tool it reported errors like:

> epoch has compression option set to gzip. ISTP Epoch variables should not be compressed.

## Changes

- Add `_variable_compression()` to centralize per-variable compression selection.
- Automatically set `Compress=0` for ISTP epoch variables matching `epoch` or `epoch_N`.
- Add `compression_skip_vars` for callers that need to force additional variables to be written uncompressed.
- Preserve existing behavior for all non-epoch variables, which continue to use the caller-provided `compression` value.

## Validation

Added tests covering:

- Default epoch behavior with `compression=6`:
  - `epoch Compress == 0`
  - `epoch_1 Compress == 0`
  - normal data variable `Compress == 6`
- Caller-provided skip list:
  - variables listed in `compression_skip_vars` are written with `Compress == 0`

Local verification:

```bash
uv run --extra tests python -m pytest \
  tests/test_xarray_reader_writer.py::test_xarray_to_cdf_skips_epoch_compression_by_default \
  tests/test_xarray_reader_writer.py::test_xarray_to_cdf_compression_skip_vars \
  --no-cov
