### PR TITLE
Write ISTP BIN_LOCATION attributes as CDF_REAL4

### DIFF
--- a/cdflib/xarray/xarray_to_cdf.py
+++ b/cdflib/xarray/xarray_to_cdf.py
@@ -1190,6 +1190,10 @@ def xarray_to_cdf(
                             if DATATYPES_TO_STRINGS[cdf_data_type] in ("CDF_EPOCH", "CDF_EPOCH16", "CDF_TIME_TT2000"):
                                 att_data = _unixtime_to_cdf_time(att_value, cdf_epoch=cdf_epoch, cdf_epoch16=cdf_epoch16)
                                 var_att_dict[att] = [att_data, DATATYPES_TO_STRINGS[cdf_data_type]]
+                elif att.upper() == "BIN_LOCATION" and istp:
+                    # ISTP defines BIN_LOCATION as a REAL*4 variable attribute.
+                    # See https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#BIN_LOCATION
+                    var_att_dict[att] = [np.float32(att_value), "CDF_REAL4"]
                 elif (att == "VALIDMIN" or att == "VALIDMAX" or att == "FILLVAL") and istp:
                     var_att_dict[att] = [att_value, DATATYPES_TO_STRINGS[cdf_data_type]]
 

--- a/tests/test_xarray_reader_writer.py
+++ b/tests/test_xarray_reader_writer.py
@@ -401,6 +401,58 @@ def test_xarray_to_cdf_compression_skip_vars(tmp_path):
         assert cdf.varinq("data").Compress == 0
 
 
+def test_xarray_to_cdf_writes_istp_bin_location_as_real4(tmp_path):
+    pytest.importorskip("xarray")
+
+    epoch_data = np.array(["2001-01-01T00:00:00", "2001-01-01T00:00:01"], dtype="datetime64[ns]")
+    epoch = xr.Variable(["epoch"], epoch_data, {"BIN_LOCATION": 0})
+    data = xr.Variable(
+        ["epoch"],
+        [1.0, 2.0],
+        {
+            "DEPEND_0": "epoch",
+            "VAR_TYPE": "data",
+            "BIN_LOCATION": 0.5,
+            "VALIDMIN": 0.0,
+            "VALIDMAX": 10.0,
+            "FILLVAL": -1e31,
+        },
+    )
+    ds = xr.Dataset(data_vars={"data": data, "epoch": epoch})
+
+    file_path = tmp_path / "bin_location_real4.cdf"
+
+    xarray_to_cdf(ds, file_path, istp=True)
+
+    with CDF(file_path) as cdf:
+        epoch_bin_location = cdf.attget("BIN_LOCATION", "epoch")
+        data_bin_location = cdf.attget("BIN_LOCATION", "data")
+
+        assert epoch_bin_location.Data_Type == "CDF_REAL4"
+        assert epoch_bin_location.Data == np.float32(0)
+        assert data_bin_location.Data_Type == "CDF_REAL4"
+        assert data_bin_location.Data == np.float32(0.5)
+
+
+def test_xarray_to_cdf_preserves_non_istp_bin_location_type_inference(tmp_path):
+    pytest.importorskip("xarray")
+
+    epoch_data = np.array(["2001-01-01T00:00:00", "2001-01-01T00:00:01"], dtype="datetime64[ns]")
+    epoch = xr.Variable(["epoch"], epoch_data)
+    data = xr.Variable(["epoch"], [1.0, 2.0], {"BIN_LOCATION": 0})
+    ds = xr.Dataset(data_vars={"data": data, "epoch": epoch})
+
+    file_path = tmp_path / "bin_location_non_istp.cdf"
+
+    xarray_to_cdf(ds, file_path, istp=False)
+
+    with CDF(file_path) as cdf:
+        bin_location = cdf.attget("BIN_LOCATION", "data")
+
+        assert bin_location.Data_Type == "CDF_INT8"
+        assert bin_location.Data == np.int64(0)
+
+
 def test_smoke(cdf_path, tmp_path):
     a = cdf_to_xarray(cdf_path, fillval_to_nan=True)
     xarray_to_cdf(a, tmp_path / cdf_path.name)


### PR DESCRIPTION
## Summary

Write ISTP `BIN_LOCATION` variable attributes as `CDF_REAL4` when using `xarray_to_cdf(..., istp=True)`.

SPDF ISTP validation expects `BIN_LOCATION` to be stored as REAL*4 / `CDF_REAL4`. Previously, cdflib relied on generic attribute type inference, so values like `0` were written as `CDF_INT8` and values like `0.5` were written as `CDF_DOUBLE`.

That produced SPDF validation errors such as:

~~~text
Bin_location has a data type of CDF_INT8. It should be CDF_REAL4.
Bin_location has a data type of CDF_DOUBLE. It should be CDF_REAL4.
~~~

## Details

`BIN_LOCATION` is an ISTP variable attribute describing where a timestamp falls within a measurement bin. The SPDF ISTP guide defines it as a REAL*4 attribute:

https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#BIN_LOCATION

This PR adds a narrow ISTP-mode special case in `xarray_to_cdf` so `BIN_LOCATION` is serialized as:

~~~python
[np.float32(value), "CDF_REAL4"]
~~~

The behavior only applies when `istp=True`. Non-ISTP writes continue to use the existing inferred attribute type behavior.

## Validation

Added regression tests for:

- Integer `BIN_LOCATION` values written as `CDF_REAL4` in ISTP mode.
- Fractional `BIN_LOCATION` values written as `CDF_REAL4` in ISTP mode.
- Non-ISTP writes preserving existing type inference.

Targeted test run:

~~~bash
pytest tests/test_xarray_reader_writer.py -k 'bin_location or compression_skip_vars or skips_epoch_compression'
~~~

Result:

~~~text
4 passed
~~~

Validated against a real IMAP CDF that previously triggered the SPDF checker error. Before rewriting:

~~~text
epoch BIN_LOCATION:    CDF_INT8
latitude BIN_LOCATION: CDF_DOUBLE
~~~

After rewriting through this branch:

~~~text
epoch BIN_LOCATION:    CDF_REAL4
latitude BIN_LOCATION: CDF_REAL4
~~~

The SPDF Java checker no longer reports the `Bin_location has a data type ... should be CDF_REAL4` errors on the rewritten file.

Related IMAP validation context:

https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/2577
