### PR TITLE
Fix xarray compression handling for SPDF epoch-like time variables

### DIFF
--- a/cdflib/xarray/xarray_to_cdf.py
+++ b/cdflib/xarray/xarray_to_cdf.py
@@ -143,8 +143,42 @@ def _is_istp_epoch_variable(var_name: str) -> Union[re.Match, None]:
     return epoch_regex_1.match(var_name.lower()) or epoch_regex_2.match(var_name.lower())
 
 
-def _variable_compression(var_name: str, compression: int, compression_skip_vars: List[str]) -> int:
-    if _is_istp_epoch_variable(var_name) or var_name in compression_skip_vars:
+def _is_spdf_epoch_like_variable(
+    var_name: str,
+    cdf_data_type: int,
+    dims: Tuple[str, ...],
+    dim_sizes: List[int],
+    record_vary: bool,
+) -> bool:
+    # Mirror the SPDF Java checker Epoch.isEpoch() logic as closely as we can at the
+    # xarray layer. True ISTP epoch variables are time-typed, scalar in CDF terms,
+    # record-varying, and not named range_epoch. Before ISTP dimension inference runs,
+    # xarray time coordinates still appear as 1D variables over their own dimension,
+    # so treat that representation as epoch-like for compression decisions too.
+    is_time_type = cdf_data_type in (
+        STRINGS_TO_DATATYPES["CDF_EPOCH"],
+        STRINGS_TO_DATATYPES["CDF_EPOCH16"],
+        STRINGS_TO_DATATYPES["CDF_TIME_TT2000"],
+    )
+    is_epoch_coordinate = len(dims) == 1 and dims[0] == var_name
+
+    return (
+        is_time_type
+        and var_name.lower() != "range_epoch"
+        and (_is_istp_epoch_variable(var_name) or ((not dim_sizes and record_vary) or is_epoch_coordinate))
+    )
+
+
+def _variable_compression(
+    var_name: str,
+    cdf_data_type: int,
+    dims: Tuple[str, ...],
+    dim_sizes: List[int],
+    record_vary: bool,
+    compression: int,
+    compression_skip_vars: List[str],
+) -> int:
+    if _is_spdf_epoch_like_variable(var_name, cdf_data_type, dims, dim_sizes, record_vary) or var_name in compression_skip_vars:
         return 0
 
     return compression
@@ -933,8 +967,9 @@ def xarray_to_cdf(
     compression : int, optional
         The level of compression to gzip the data in the variables.  Default is no compression, standard is 6.
     compression_skip_vars : list of str, optional
-        Additional variables to write without compression when compression is enabled. ISTP epoch variables named
-        "epoch" or "epoch_N" are always written without compression.
+        Additional variables to write without compression when compression is enabled. Variables that match the
+        SPDF ISTP epoch predicate are always written without compression. This includes scalar, record-varying
+        CDF_EPOCH, CDF_EPOCH16, and CDF_TIME_TT2000 variables, except for ``range_epoch``.
     nan_to_fillval : bool, optional
         Convert all np.nan and np.datetime64('NaT') to the standard CDF FILLVALs.
 
@@ -1203,7 +1238,15 @@ def xarray_to_cdf(
                 "Num_Elements": cdf_num_elements,
                 "Rec_Vary": record_vary,
                 "Dim_Sizes": dim_sizes,
-                "Compress": _variable_compression(var, compression, compression_skip_vars),
+                "Compress": _variable_compression(
+                    var,
+                    cdf_data_type,
+                    d[var].dims,
+                    dim_sizes,
+                    record_vary,
+                    compression,
+                    compression_skip_vars,
+                ),
             }
 
             x.write_var(var_spec, var_attrs=var_att_dict, var_data=var_data)

--- a/tests/test_xarray_reader_writer.py
+++ b/tests/test_xarray_reader_writer.py
@@ -384,6 +384,44 @@ def test_xarray_to_cdf_skips_epoch_compression_by_default(tmp_path):
         assert cdf.varinq("data").Compress == 6
 
 
+def test_xarray_to_cdf_skips_spdf_epoch_like_time_variable_compression(tmp_path):
+    pytest.importorskip("xarray")
+
+    time_data = np.array(["2001-01-01T00:00:00", "2001-01-01T00:00:01"], dtype="datetime64[ns]")
+    on_off_times = xr.Variable(["on_off_times"], time_data, {"CDF_DATA_TYPE": "CDF_TIME_TT2000"})
+    on_off_events = xr.Variable(
+        ["on_off_times"],
+        [0, 1],
+        {"DEPEND_0": "on_off_times", "VAR_TYPE": "support_data"},
+    )
+    ds = xr.Dataset(data_vars={"on_off_events": on_off_events, "on_off_times": on_off_times})
+
+    file_path = tmp_path / "epoch_like_compression.cdf"
+
+    xarray_to_cdf(ds, file_path, istp=False, compression=6)
+
+    with CDF(file_path) as cdf:
+        assert cdf.varinq("on_off_times").Compress == 0
+        assert cdf.varinq("on_off_events").Compress == 6
+
+
+def test_xarray_to_cdf_keeps_range_epoch_compression_enabled(tmp_path):
+    pytest.importorskip("xarray")
+
+    time_data = np.array(["2001-01-01T00:00:00", "2001-01-01T00:00:01"], dtype="datetime64[ns]")
+    range_epoch = xr.Variable(["range_epoch"], time_data, {"CDF_DATA_TYPE": "CDF_EPOCH"})
+    data = xr.Variable(["range_epoch"], [1.0, 2.0], {"DEPEND_0": "range_epoch", "VAR_TYPE": "data"})
+    ds = xr.Dataset(data_vars={"data": data, "range_epoch": range_epoch})
+
+    file_path = tmp_path / "range_epoch_compression.cdf"
+
+    xarray_to_cdf(ds, file_path, istp=False, compression=6)
+
+    with CDF(file_path) as cdf:
+        assert cdf.varinq("range_epoch").Compress == 6
+        assert cdf.varinq("data").Compress == 6
+
+
 def test_xarray_to_cdf_compression_skip_vars(tmp_path):
     pytest.importorskip("xarray")
 


### PR DESCRIPTION
## Summary

This PR broadens `cdflib`'s automatic compression-skip logic for time variables so it better matches the SPDF Java ISTP checker.

Previously, `xarray_to_cdf()` only disabled compression for variables named `epoch` or `epoch_N`. That was too narrow for ISTP validation. In particular, time-typed support variables such as IDEX `on_off_times` were still being written with gzip compression even though the SPDF validator treats them as epoch-like variables that should not be compressed.

## What Changed

The xarray writer now treats a variable as SPDF epoch-like for compression purposes when it:

- has a time CDF datatype:
  - `CDF_EPOCH`
  - `CDF_EPOCH16`
  - `CDF_TIME_TT2000`
- is not `range_epoch`
- and either:
  - is scalar in final CDF terms and record-varying, or
  - is an xarray time coordinate over its own dimension

The previous `epoch` / `epoch_N` behavior is preserved, so existing ISTP epoch variables continue to be written without compression.

This change is intentionally scoped to the xarray writer’s compression policy. It does not change the lower-level CDF writer behavior more broadly.

## Why

The SPDF Java checker does not key this rule only off the variable name `epoch`. Its epoch compliance logic identifies the file’s ISTP epoch variable based on time datatype and variable shape/variance, then enforces that it not be compressed.

This PR brings `cdflib` closer to that behavior so local CDF generation aligns better with SPDF validation.

## Testing

Added regression coverage to verify that:

- `epoch` is still written uncompressed by default
- `epoch_1` is still written uncompressed by default
- an `on_off_times`-style TT2000 variable is written uncompressed
- `range_epoch` remains compressible
- `compression_skip_vars` still works as expected

Validated locally with:

```bash
cd /mnt/c/Dropbox/princeton/imap/cdflib
/home/david/.virtualenvs/imap/bin/python -m pytest -q tests/test_xarray_reader_writer.py -k 'compression'