### PR TITLE
Do not silently read a different file for a non-existent path with a suffix (fixes #328)

### DIFF
--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -88,11 +88,17 @@ class CDF:
             self.ftype = "file"
             path = Path(path).resolve().expanduser()
             if not path.is_file():
-                path = path.with_suffix(".cdf")
+                # Fall back to appending a ``.cdf`` extension only when the
+                # path has no suffix (e.g. the user passed ``mydata`` instead
+                # of ``mydata.cdf``). ``Path.with_suffix`` *replaces* the last
+                # suffix, so for a non-existent path that already has one,
+                # e.g. ``mydata.cdfINVALID``, it used to silently resolve to
+                # ``mydata.cdf`` and read the wrong file (GH #328).
+                if not path.suffix:
+                    path = path.with_suffix(".cdf")
                 if not path.is_file():
                     raise FileNotFoundError(f"{path} not found")
             self.file = path  # path for files, fname for urls and S3
-            self.file = path
 
         self.string_encoding = string_encoding
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.3.13
+======
+
+cdfread
+-------
+- Reading a non-existent path built from a valid path plus extra characters (e.g. ``file.cdfINVALID``) now raises ``FileNotFoundError`` instead of silently falling back to ``file.cdf`` and reading a different file (#328)
+
 1.3.9
 =====
 

--- a/tests/test_cdfread.py
+++ b/tests/test_cdfread.py
@@ -28,3 +28,13 @@ def test_read(cdf_path):
 def test_nonexist_file_errors(tmp_path):
     with pytest.raises(FileNotFoundError, match="not found"):
         CDF(tmp_path / "nonexist.cdf")
+
+
+def test_nonexist_path_with_extra_suffix_errors(cdf_path):
+    # A non-existent path built from a real CDF path plus extra characters
+    # must raise instead of silently reading the real file. Previously the
+    # ``.cdf`` fallback used ``Path.with_suffix`` which replaces the suffix,
+    # so ``<real>.cdfINVALID`` resolved back to ``<real>.cdf`` (GH #328).
+    bad_path = str(cdf_path) + "INVALID"
+    with pytest.raises(FileNotFoundError, match="not found"):
+        CDF(bad_path)


### PR DESCRIPTION
## Problem (#328)

`cdflib.cdfread.CDF()` can read a CDF from an **illegal path** built from a legal path plus extra characters. For example, passing `mydata.cdfINVALID` (which does not exist) silently reads `mydata.cdf` instead of raising:

```python
>>> import cdflib
>>> cdflib.cdfread.CDF('tests/testfiles/psp_fld_l2_mag_rtn_1min_20200104_v02.cdfINVALID').cdf_info().CDF
PosixPath('.../psp_fld_l2_mag_rtn_1min_20200104_v02.cdf')   # wrong file, no error
```

This is a data-integrity hazard: a user can get data from a file other than the one they asked for, with no indication anything went wrong. (Reported by @ErikPGJ for JUICE/RPWI files; the upper character limit they observed before an error simply corresponds to the OS path-length limit hit in `Path.is_file()`.)

## Cause

In the `file` branch of `CDF.__init__`:

```python
if not path.is_file():
    path = path.with_suffix(".cdf")
    if not path.is_file():
        raise FileNotFoundError(f"{path} not found")
```

`Path.with_suffix('.cdf')` **replaces** the last suffix rather than appending one, so `mydata.cdfINVALID` → `mydata.cdf`. The fallback was presumably meant for the *"user passed `mydata` without the `.cdf` extension"* case, but it also rewrites any wrong-but-present extension to `.cdf`.

## Fix

Only apply the `.cdf` fallback when the path has **no** suffix:

```python
if not path.is_file():
    if not path.suffix:
        path = path.with_suffix(".cdf")
    if not path.is_file():
        raise FileNotFoundError(f"{path} not found")
```

- `mydata` (no suffix) → still falls back to `mydata.cdf` (behavior preserved).
- `mydata.cdfINVALID` (has a suffix) → no longer clobbered → `FileNotFoundError`.
- An existing `mydata.cdf` is found before the fallback is ever reached, so valid reads are unaffected.

(Also drops a duplicated `self.file = path` line in the same block.)

## Tests

Adds `test_nonexist_path_with_extra_suffix_errors`, which asserts that a real test-file path with extra characters appended raises `FileNotFoundError`. It fails on `main` (DID NOT RAISE) and passes with the fix; `tests/test_cdfread.py` passes (5 passed). Verified the no-suffix fallback still resolves `<name>` → `<name>.cdf`.

Fixes #328.