### PR TITLE
Avoid generic-unit timedelta in CDFepoch.to_datetime (fixes #333)

### DIFF
--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -177,8 +177,16 @@ class CDFepoch:
         vals = (v for v in (years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds) if v is not None)
 
         arrays: List[npt.NDArray[np.datetime64]] = [np.array(v, dtype=t) for t, v in zip(types, vals)]
-        total_datetime = np.array(sum(arrays))
-        total_datetime = np.where(nat_positions, np.datetime64("NaT"), total_datetime)
+        # Sum the components starting from the first array (a datetime64)
+        # rather than the implicit integer ``0`` used by ``sum``: adding a
+        # bare integer to a datetime64 yields a generic-unit timedelta, which
+        # NumPy deprecates and will eventually turn into an error (#333).
+        total_datetime = np.array(sum(arrays[1:], arrays[0]))
+        # Build the NaT with the same unit as the data; the bare
+        # ``np.datetime64("NaT")`` is generic-unit and triggers the same
+        # deprecation when combined with ``total_datetime`` in ``np.where``.
+        nat = np.datetime64("NaT", np.datetime_data(total_datetime.dtype)[0])
+        total_datetime = np.where(nat_positions, nat, total_datetime)
         return total_datetime
 
     @classmethod

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -2,6 +2,7 @@
 import filecmp
 import os
 import urllib.request
+import warnings
 from datetime import datetime, timedelta
 from pathlib import Path
 from random import randint
@@ -228,6 +229,18 @@ def test_parse_cdftt2000():
     assert parsed == input_time
 
     assert cdfepoch().to_datetime(parsed).astype("datetime64[us]").item() == datetime(2004, 3, 1, 12, 24, 22, 351793)
+
+
+def test_to_datetime_no_generic_timedelta_warning():
+    # Regression test for #333: composing the result must not rely on a
+    # generic-unit timedelta (adding a bare integer to a datetime64), which
+    # NumPy >= 2.5 deprecates and will eventually turn into an error.
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        result = cdfepoch.to_datetime(631377279184000000)
+    generic = [r for r in records if issubclass(r.category, DeprecationWarning) and "generic" in str(r.message)]
+    assert not generic
+    assert result.astype("datetime64[us]").item() == datetime(2020, 1, 4, 2, 33, 30)
 
 
 def test_findepochrange_cdfepoch():


### PR DESCRIPTION
## Summary

`CDFepoch.to_datetime` raises a `DeprecationWarning` under NumPy 2.5+:

```
DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will
raise an error in the future. This includes implicit conversion of bare integers
(e.g. `+ 1`). Please use a specific unit instead.
```

Reproducer from #333:

```python
import warnings
warnings.simplefilter('always')
from cdflib.epochs import CDFepoch
CDFepoch.to_datetime(631377279184000000)   # warns twice
```

## Cause

In `_compose_date` (`cdflib/epochs.py`):

- `total_datetime = np.array(sum(arrays))` — `sum` starts from the integer `0`, so the first operation is `0 + datetime64[...]`. Adding a bare integer to a datetime64 yields a *generic-unit* timedelta, which NumPy now deprecates.
- `np.where(nat_positions, np.datetime64('NaT'), total_datetime)` — the bare `np.datetime64('NaT')` is also generic-unit and triggers the same warning when combined with the typed `total_datetime`.

## Fix

- Sum the components starting from the first array (a `datetime64`) instead of the implicit `0`.
- Build `NaT` with the same unit as the data (`np.datetime_data(total_datetime.dtype)[0]`).

Both are behaviour-preserving — only the intermediate dtypes change, not the result.

## Verification

- Reproduced the two warnings on a NumPy nightly (`2.6.0.dev`); after the fix, `to_datetime` emits no `generic`-unit `DeprecationWarning` and returns the identical value.
- Full test suite green on released NumPy 2.4.6 (82 passed); the epoch tests pass on both released and nightly NumPy.
- Added `test_to_datetime_no_generic_timedelta_warning`, which fails on the current code under the nightly and passes with the fix (and passes trivially on older NumPy that doesn't emit the warning).