### PR TITLE
Skip untypeable attribute entries instead of aborting the whole write

### DIFF
--- a/cdflib/cdfwrite.py
+++ b/cdflib/cdfwrite.py
@@ -393,8 +393,8 @@ class CDF:
                                 data = value[0]
                                 if dataType == self.CDF_CHAR or dataType == self.CDF_UCHAR:
                                     if isinstance(data, list) or isinstance(data, tuple):
-                                        logger.warning("Invalid global attribute value")
-                                        return
+                                        logger.warning(f"Invalid global attribute value for {attr}, skipping entry")
+                                        continue
                                     numElems = len(data)
                                 elif dataType == self.CDF_EPOCH or dataType == self.CDF_EPOCH16 or dataType == self.CDF_TIME_TT2000:
                                     cvalue = []
@@ -430,8 +430,8 @@ class CDF:
                         data = value
                         numElems, dataType = self._datatype_define(value)
                         if numElems is None:
-                            logger.warning("Unknown data")
-                            return
+                            logger.warning(f"Unknown data type for {attr}, skipping entry")
+                            continue
 
                     offset = self._write_aedr(f, True, attrNum, entryNum, data, dataType, numElems, None)
                     if entries == 0:
@@ -583,8 +583,8 @@ class CDF:
                         data = value
                         numElems, dataType = self._datatype_define(value)
                         if numElems is None:
-                            logger.warning("Unknown data")
-                            return
+                            logger.warning(f"Unknown data type for {attr}, skipping entry")
+                            continue
                     offset = self._write_aedr(f, False, attrNum, entryNum, data, dataType, numElems, zVar)
                     if entries == 0:
                         if zVar:

--- a/tests/test_cdfwrite.py
+++ b/tests/test_cdfwrite.py
@@ -725,3 +725,53 @@ def test_write_empty_variable_with_compression(tmp_path):
     reader = cdf_read(fn)
     info = reader.varinq("EmptyVar")
     assert info.Last_Rec == -1
+
+
+def test_globalattrs_skip_none_entry(tmp_path):
+    # A global attribute with an untypeable (e.g. None) value must not abort
+    # writing the attributes that follow it (GH #319).
+    fn = tmp_path / fnbasic
+
+    globalAttrs: Dict[str, Any] = {}
+    globalAttrs["Before"] = {0: "value before"}
+    globalAttrs["NoneAttr"] = {0: None}
+    globalAttrs["After"] = {0: "value after"}
+
+    tfile = cdf_create(fn, {"Checksum": True})
+    tfile.write_globalattrs(globalAttrs)
+    tfile.close()
+
+    attrs = cdf_read(fn).globalattsget()
+    # The attribute after the offending one is still written ...
+    assert attrs["Before"] == ["value before"]
+    assert attrs["After"] == ["value after"]
+    # ... and the offending entry is simply skipped.
+    assert attrs.get("NoneAttr", []) == []
+
+
+def test_variableattrs_skip_none_entry(tmp_path):
+    # Same guarantee for variable attributes: an untypeable value must not drop
+    # the variable attributes that follow it (GH #319).
+    fn = tmp_path / fnbasic
+
+    vs: Dict[str, Any] = {}
+    vs["Variable"] = "Variable1"
+    vs["Data_Type"] = 8
+    vs["Num_Elements"] = 1
+    vs["Rec_Vary"] = True
+    vs["Dim_Sizes"] = []
+
+    tfile = cdf_create(fn, {"Checksum": True})
+    tfile.write_var(vs, var_data=np.array([0, 1, 2]))
+    tfile.write_variableattrs(
+        {
+            "AttrBefore": {"Variable1": "before"},
+            "NoneAttr": {"Variable1": None},
+            "AttrAfter": {"Variable1": "after"},
+        }
+    )
+    tfile.close()
+
+    attrs = cdf_read(fn).varattsget("Variable1")
+    assert attrs["AttrBefore"] == "before"
+    assert attrs["AttrAfter"] == "after"


### PR DESCRIPTION
Fixes #319.

## Problem

`write_globalattrs()` returns out of the entire function when an attribute value cannot be typed — for example a value of `None`:

```python
numElems, dataType = self._datatype_define(value)
if numElems is None:
    logger.warning("Unknown data")
    return   # aborts the whole loop, dropping every attribute that follows
```

So when an `xarray.Dataset` has a global attribute set to `None`, that attribute **and every global attribute after it** are silently missing from the written CDF, as reported in #319. `write_variableattrs()` has the identical pattern for variable attributes, and there is a third matching `return` on an invalid `CDF_CHAR` list/tuple value.

## Fix

Replace those three `return`s with `continue`, so an untypeable or invalid entry is skipped while the remaining attributes are still written. The warning message now names the attribute being skipped, to make the (previously very confusing) silent loss diagnosable.

## Tests

Adds `test_globalattrs_skip_none_entry` and `test_variableattrs_skip_none_entry` to `tests/test_cdfwrite.py`: each writes an attribute before a `None`-valued attribute and one after it, then reads back and asserts the trailing attribute survived. Both fail before this change and pass after; the full `test_cdfwrite.py` suite (27 tests) passes.