### PR TITLE
Match variable names case-sensitively in varget/varattsget (fixes #314)

### DIFF
--- a/cdflib/cdfread.py
+++ b/cdflib/cdfread.py
@@ -446,26 +446,42 @@ class CDF:
             endrec=endrec,
         )
 
+    def _find_variable_position(self, variable: str) -> Tuple[int, bool]:
+        """Locate a variable's VDR by name, checking z variables then r variables.
+
+        CDF variable names are case-sensitive (see the CDF manual), so an exact
+        match is preferred. A case-insensitive match is kept only as a fallback,
+        used when no exact match exists, to preserve backward-compatible lookups.
+
+        Returns ``(position, is_zvariable)``; raises ``ValueError`` if not found.
+        """
+        target = variable.strip()
+        target_lower = target.lower()
+        fallback: Optional[Tuple[int, bool]] = None
+        position = self._first_zvariable
+        num_variables = self._num_zvariable
+        for is_zvar in (True, False):
+            for _ in range(0, num_variables):
+                name, vdr_next = self._read_vdr_fast(position)
+                stripped = name.strip()
+                if stripped == target:
+                    return position, is_zvar
+                if fallback is None and stripped.lower() == target_lower:
+                    fallback = (position, is_zvar)
+                position = vdr_next
+            position = self._first_rvariable
+            num_variables = self._num_rvariable
+        if fallback is not None:
+            return fallback
+        raise ValueError(f"Variable name '{variable}' not found.")
+
     def vdr_info(self, variable: Union[str, int]) -> VDR:
         if isinstance(variable, int) and self._num_zvariable > 0 and self._num_rvariable > 0:
             raise ValueError("This CDF has both r and z variables. " "Use variable name instead")
 
         if isinstance(variable, str):
-            # Check z variables for the name, then r variables
-            position = self._first_zvariable
-            num_variables = self._num_zvariable
-            vdr_info = None
-            for zVar in [1, 0]:
-                for _ in range(0, num_variables):
-                    name, vdr_next = self._read_vdr_fast(position)
-                    if name.strip().lower() == variable.strip().lower():
-                        vdr_info = self._read_vdr(position)
-                        break
-                    position = vdr_next
-                position = self._first_rvariable
-                num_variables = self._num_rvariable
-            if vdr_info is None:
-                raise ValueError(f"Variable name '{variable}' not found.")
+            position, _ = self._find_variable_position(variable)
+            vdr_info = self._read_vdr(position)
         elif isinstance(variable, int):
             if self._num_zvariable > 0:
                 position = self._first_zvariable
@@ -534,18 +550,9 @@ class CDF:
         if isinstance(variable, int) and self._num_zvariable > 0 and self._num_rvariable > 0:
             raise ValueError("This CDF has both r and z variables. Use variable name")
         if isinstance(variable, str):
-            position = self._first_zvariable
-            num_variables = self._num_zvariable
-            for zVar in [True, False]:
-                for _ in range(0, num_variables):
-                    name, vdr_next = self._read_vdr_fast(position)
-                    if name.strip().lower() == variable.strip().lower():
-                        vdr_info = self._read_vdr(position)
-                        return self._read_varatts(vdr_info.variable_number, zVar)
-                    position = vdr_next
-                position = self._first_rvariable
-                num_variables = self._num_rvariable
-            raise ValueError(f"No variable by this name: {variable}")
+            position, zVar = self._find_variable_position(variable)
+            vdr_info = self._read_vdr(position)
+            return self._read_varatts(vdr_info.variable_number, zVar)
         elif isinstance(variable, int):
             if self._num_zvariable > 0:
                 num_variable = self._num_zvariable

--- a/tests/test_cdfwrite.py
+++ b/tests/test_cdfwrite.py
@@ -725,3 +725,43 @@ def test_write_empty_variable_with_compression(tmp_path):
     reader = cdf_read(fn)
     info = reader.varinq("EmptyVar")
     assert info.Last_Rec == -1
+
+
+def _write_named_vars(fn, named_data):
+    tfile = cdf_create(fn, {})
+    for name, data in named_data:
+        var_spec = {
+            "Variable": name,
+            "Data_Type": 4,
+            "Num_Elements": 1,
+            "Rec_Vary": True,
+            "Dim_Sizes": [],
+        }
+        tfile.write_var(var_spec, var_data=np.array(data))
+    tfile.close()
+
+
+def test_varget_is_case_sensitive(tmp_path):
+    # CDF variable names are case-sensitive (gh #314): two variables differing
+    # only in case must each return their own data, not the first one matched.
+    fn = tmp_path / fnbasic
+    _write_named_vars(fn, [("Epoch", [10, 11, 12]), ("epoch", [20, 21, 22])])
+
+    reader = cdf_read(fn)
+    np.testing.assert_equal(reader.varget("Epoch"), [10, 11, 12])
+    np.testing.assert_equal(reader.varget("epoch"), [20, 21, 22])
+    # varattsget must resolve to the same exact-case variable
+    assert reader.varattsget("epoch") is not None
+
+
+def test_varget_case_insensitive_fallback(tmp_path):
+    # With no exact-case match, a case-insensitive lookup still resolves, so
+    # existing callers that pass the wrong case keep working.
+    fn = tmp_path / fnbasic
+    _write_named_vars(fn, [("SpinPeriod", [7, 8, 9])])
+
+    reader = cdf_read(fn)
+    np.testing.assert_equal(reader.varget("spinperiod"), [7, 8, 9])
+    np.testing.assert_equal(reader.varget("SPINPERIOD"), [7, 8, 9])
+    with pytest.raises(ValueError):
+        reader.varget("NoSuchVariable")


### PR DESCRIPTION
Fixes #314.

## Problem

CDF variable names are case-sensitive ([CDF manual](https://cdf.gsfc.nasa.gov/manual/node72.html)), but `vdr_info` (used by `varget`/`varinq`) and `varattsget` compared names with `.lower()` on **both** sides:

```python
if name.strip().lower() == variable.strip().lower():
```

So when a file contains two variables that differ only in case, both resolve to whichever was stored first — silently returning the wrong data. This came up with real ERG-project files that renamed variables from mixed case to lower case.

Reproduction (two variables `Epoch` and `epoch`):

```python
r.varget("Epoch")  # [10, 11, 12]  ✓
r.varget("epoch")  # [10, 11, 12]  ✗  (should be [20, 21, 22])
```

## Fix

Added a small shared helper `_find_variable_position` that prefers an **exact** (case-sensitive) match and only falls back to a case-insensitive match when no exact match exists. Both `vdr_info` and `varattsget` now use it (removing the duplicated z/r lookup loop). This:

- fixes the case-collision so each variable returns its own data, and
- keeps existing wrong-case lookups working when there is no exact match, so it is backward compatible.

After the fix `r.varget("epoch")` returns `[20, 21, 22]`.

## Tests

`tests/test_cdfwrite.py`:
- `test_varget_is_case_sensitive` — two variables differing only in case each return their own data (fails on `main`, passes here).
- `test_varget_case_insensitive_fallback` — a wrong-case query still resolves when there is no exact match, and an unknown name still raises.

Full `test_cdfread.py` + `test_cdfwrite.py` pass (30/30); the pre-existing `test_xarray_reader_writer.py` failures are unchanged by this PR (identical 17 failing on `main`). `black --line-length 132` clean.